### PR TITLE
add missing "istanbul" devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "grunt-mocha-istanbul": "^2.2.0",
     "grunt-mocha-test": "^0.12.4",
     "grunt-scss-lint": "^0.3.6",
+    "istanbul": "^0.3.17",
     "karma": "^0.12.28",
     "karma-chrome-launcher": "^0.1.7",
     "karma-mocha": "^0.1.9",


### PR DESCRIPTION
"istanbul" is a peer dependency of "grunt-mocha-istanbul".
Starting with npm v3.0.0 it won't be be automatically installed
anymore and an explicit dependency is required.

Warning from npm v2.x
```shell
npm WARN peerDependencies The peer dependency istanbul@0.x.x included from grunt-mocha-istanbul will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
```