### PR TITLE
fix sign-in link hover color

### DIFF
--- a/src/client/assets/styles/_landing-page.scss
+++ b/src/client/assets/styles/_landing-page.scss
@@ -87,8 +87,8 @@ img.step-icon{
 //   margin: 20px;
 // }
 //
-a .lp-signin:hover, a .lp-signin:focus {
-  color: $text-color;
+a.lp-signin:hover, a.lp-signin:focus {
+  color: $text-invert;
 }
 
 /*.feature-title-add, .feature-title-remove,


### PR DESCRIPTION
upper right "Sign In" link has a dark hover color which is hard
to read as the background image is quite dark as well.
changed the color to be the same as without hover (white).

Before
![before](https://cloud.githubusercontent.com/assets/1410947/8439941/76992186-1f6f-11e5-94ae-f41b8bf693c8.png)

After
![after9](https://cloud.githubusercontent.com/assets/1410947/8439958/8582d138-1f6f-11e5-88f0-312e98563df3.png)
