### PR TITLE
Remove apostrophe from plural for CLAs

### DIFF
--- a/DESCRIPTION.MD
+++ b/DESCRIPTION.MD
@@ -1,8 +1,8 @@
 ### Tagline
-Manages the signing of Contributor License Agreements (CLA's) within GitHub Flow.
+Manages the signing of Contributor License Agreements (CLAs) within GitHub Flow.
 
 ### Short Description
-Streamline your workflow and let CLA assistant handle the legal side of contributions to a repository for you. CLA assistant enables contributors to sign CLA's from within a pull request.
+Streamline your workflow and let CLA assistant handle the legal side of contributions to a repository for you. CLA assistant enables contributors to sign CLAs from within a pull request.
 
 ### Description
 To get started, simply store your CLA as a GitHub Gist file then link it with the repository in CLA assistant. Then sit back and relax while CLA assistant:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Contributor License Agreement assistant
 ===
-Streamline your workflow and let CLA assistant handle the legal side of contributions to a repository for you. CLA assistant enables contributors to sign CLA's from within a pull request.
+Streamline your workflow and let CLA assistant handle the legal side of contributions to a repository for you. CLA assistant enables contributors to sign CLAs from within a pull request.
 
 To get started, simply store your CLA as a GitHub Gist file then link it with the repository in CLA assistant. Then sit back and relax while CLA assistant:
 

--- a/src/client/login.html
+++ b/src/client/login.html
@@ -74,7 +74,7 @@
 			<div class="row lp-premium lp-section">
 				<img class="center-block img-responsive" src="/assets/images/CLA_text.svg" style="width:200px">
 				<div class="center-block" style="font-size:25px;font-weight:200;line-height:36px; margin-top:30px;">
-					<p>Easily handle Contributor License Agreements (CLA's)</p>
+					<p>Easily handle Contributor License Agreements (CLAs)</p>
 					<btn class="btn btn-md btn-primary" ng-click="logAdminIn()" style="margin-top:20px; width:195px; font-size: 16px">
 						<span class="octicon octicon-mark-github"></span>&nbsp;Sign in with GitHub</btn>
 				</div>

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -77,7 +77,7 @@
 	<!-- <h2 class="text-primary">Contributor License Agreement assistant <i class="fa fa-question-circle clickable" style="font-size:18px; color: gray; vertical-align:middle" ng-click="info()"></i></h2> -->
 
 	<div class="row">
-		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Linked CLA's</h4>
+		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Linked CLAs</h4>
 	</div>
 	<div class="well row" style="padding-top:25px;">
 		  <table  class=" table">


### PR DESCRIPTION
Removing errant apostrophes from plural uses of CLA. (CLA's -> CLAs) to match with style guide: http://www.oxforddictionaries.com/words/apostrophe