### PR TITLE
Friendlier PR comment for >1 committer

### DIFF
--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -8,12 +8,13 @@ var commentText = function (signed, badgeUrl, claUrl, user_map) {
 		return '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>All committers have signed the CLA.';
 	}
 
-	var text = '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>All committers of the pull request should sign our Contributor License Agreement in order to get your pull request merged.<br/>';
 	var committersCount = 1;
-
 	if (user_map && user_map.not_signed && user_map.signed) {
 		committersCount = user_map.signed.length + user_map.not_signed.length;
 	}
+
+	var youAll = (committersCount > 1 ? 'you all' : 'you');
+	var text = '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>Thank you for your submission, we really appreciate it. Like many open source projects, we ask that ' + youAll + ' sign our [Contributor License Agreement](' + claUrl + ') before we can accept your contribution.<br/>';
 
 	if (committersCount > 1) {
 		text += '**' + user_map.signed.length + '** out of **' + (user_map.signed.length + user_map.not_signed.length) + '** committers have signed the CLA.<br/>';
@@ -23,8 +24,6 @@ var commentText = function (signed, badgeUrl, claUrl, user_map) {
 		user_map.not_signed.forEach(function (signee) {
 			text += '<br/>:x: ' + signee;
 		});
-	} else {
-		text = '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](' + claUrl + ') before we can accept your contribution.<br/>';
 	}
 
 	if (user_map && user_map.unknown && user_map.unknown.length > 0) {

--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -5,7 +5,7 @@ var log = require('../services/logger');
 
 var commentText = function (signed, badgeUrl, claUrl, user_map) {
 	if (signed) {
-		return '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>All committers have accepted the CLA.';
+		return '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>All committers have signed the CLA.';
 	}
 
 	var text = '[![CLA assistant check](' + badgeUrl + ')](' + claUrl + ') <br/>All committers of the pull request should sign our Contributor License Agreement in order to get your pull request merged.<br/>';

--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -29,7 +29,7 @@ var commentText = function (signed, badgeUrl, claUrl, user_map) {
 	if (user_map && user_map.unknown && user_map.unknown.length > 0) {
 		var seem = (user_map.unknown.length > 1 ? 'seem' : 'seems');
 		text += '<hr/>**' + user_map.unknown.join(', ') + '** ' + seem + ' not to be a GitHub user.';
-		text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please add the email address used for this commit to your account ([for further information, click here] (https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user)).';
+		text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please [add the email address used for this commit to your account](https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user).';
 	}
 	return text;
 };

--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -27,16 +27,8 @@ var commentText = function (signed, badgeUrl, claUrl, user_map) {
 	}
 
 	if (user_map && user_map.unknown && user_map.unknown.length > 0) {
-		var userNames = '';
-		user_map.unknown.forEach(function (signee) {
-			userNames += signee + ', ';
-		});
-		userNames = userNames.slice(0, -2);
-		if (user_map.unknown.length === 1) {
-			text += '<hr/>**' + userNames + '** seems not to be a GitHub user.';
-		} else {
-			text += '<hr/>**' + userNames + '** seem not to be a GitHub user.';
-		}
+		var seem = (user_map.unknown.length > 1 ? 'seem' : 'seems');
+		text += '<hr/>**' + user_map.unknown.join(', ') + '** ' + seem + ' not to be a GitHub user.';
 		text += ' You need a GitHub account to be able to sign the CLA. If you have already a GitHub account, please add the email address used for this commit to your account ([for further information, click here] (https://help.github.com/articles/why-are-my-commits-linked-to-the-wrong-user/#commits-are-not-linked-to-any-user)).';
 	}
 	return text;

--- a/src/tests/server/services/pullRequest.js
+++ b/src/tests/server/services/pullRequest.js
@@ -255,7 +255,7 @@ describe('pullRequest:badgeComment', function () {
 		direct_call_data = [];
 		sinon.stub(github, 'call', function (args, git_done) {
 			assert.equal(args.fun, 'createComment');
-			assert(args.arg.body.indexOf('All committers of the pull request should sign our Contributor License Agreement in order to get your pull request merged.<br/>') >= 0);
+			assert(args.arg.body.indexOf('sign our [Contributor License Agreement]') >= 0);
 			assert(args.arg.body.indexOf('**1** out of **2**') >= 0);
 			assert(args.arg.body.indexOf(':white_check_mark: user1') >= 0);
 			assert(args.arg.body.indexOf(':x: user2') >= 0);
@@ -290,7 +290,7 @@ describe('pullRequest:badgeComment', function () {
 		direct_call_data = testDataComments_withCLAComment;
 		sinon.stub(github, 'call', function (args, git_done) {
 			assert.equal(args.fun, 'editComment');
-			assert(args.arg.body.indexOf('All committers of the pull request should sign our Contributor License Agreement in order to get your pull request merged.<br/>') >= 0);
+			assert(args.arg.body.indexOf('sign our [Contributor License Agreement]') >= 0);
 			assert(args.arg.body.indexOf('**1** out of **2**') >= 0);
 			assert(args.arg.body.indexOf(':white_check_mark: user1') >= 0);
 			assert(args.arg.body.indexOf(':x: user2') >= 0);
@@ -449,7 +449,7 @@ describe('pullRequest:editComment', function () {
 		github.call.restore();
 		sinon.stub(github, 'call', function (params, git_done) {
 			assert.equal(params.fun, 'editComment');
-			assert(params.arg.body.indexOf('All committers of the pull request should sign our Contributor License Agreement in order to get your pull request merged.<br/>') >= 0);
+			assert(params.arg.body.indexOf('sign our [Contributor License Agreement]') >= 0);
 			assert(params.arg.body.indexOf('**1** out of **2**') >= 0);
 			assert(params.arg.body.indexOf(':white_check_mark: user1') >= 0);
 			assert(params.arg.body.indexOf(':x: user2') >= 0);

--- a/src/tests/server/services/pullRequest.js
+++ b/src/tests/server/services/pullRequest.js
@@ -209,7 +209,7 @@ describe('pullRequest:badgeComment', function () {
 		sinon.stub(github, 'call', function (args, git_done) {
 			assert.equal(args.fun, 'editComment');
 			assert.equal(args.basicAuth.user, 'cla-assistant');
-			assert(args.arg.body.indexOf('If you have already a GitHub account, please add the email address used for this commit to your account') >= 0);
+			assert(args.arg.body.indexOf('If you have already a GitHub account, please [add the email address used for this commit to your account]') >= 0);
 			git_done(null, 'res', 'meta');
 			it_done();
 		});


### PR DESCRIPTION
#110 only dealt with the case of a single committer, this uses the same language for >1 committer, too.