### PR TITLE
Allowing to specify patterns for ignored repos during org linking

### DIFF
--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -371,7 +371,8 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
             var newClaOrg = {
                 orgId: $scope.selected.item.id,
                 org: $scope.selected.item.login,
-                gist: $scope.selected.gist.url
+                gist: $scope.selected.gist.url,
+                excludePattern: $scope.selected.item.excludePattern
             };
             mixOrgData(newClaOrg);
             return linkItem('org', newClaOrg);

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -1,7 +1,4 @@
-
-
 <!-- ----------ACTIVATE a CLA---------- -->
-<!-- <div id="activate" class="content-block"> -->
 <div id="activated_cla" ng-show="user.value.admin" class="row content-block">
 
 	<div class="row" style="margin-bottom: 65px; padding-left:0px" ng-hide="newLink">
@@ -12,26 +9,23 @@
 	</div>
 
 	<div class="well row" ng-show="newLink" style="max-width:400px; position:relative;">
-		<!-- <div class="col-xs-12">
-		</div> -->
 		<div ng-click="newLink = !newLink" class="fa fa-times close-button" style="position:absolute; right:20px"></div>
 
 		<h5 class="link-topic-1">
 			<span class="link-topic-number">1</span>&nbsp;Choose a CLA
 		</h5>
 		<div class="col-xs-12">
-			<div style="margin-bottom: 5px;">Select from Gist
-				&nbsp;<span class="clickable" ng-click="info()" style="font-size:12px; text-decoration:underline">(don't have one?)</span>
+			<div style="margin-bottom: 5px;">Select from Gist &nbsp;
+				<span class="clickable" ng-click="info()" style="font-size:12px; text-decoration:underline">(don't have one?)</span>
 			</div>
 			<div class="form-group has-feedback" style="margin-bottom: 10px;">
-				<ui-select ng-model="selected.gist"  theme="selectize">
+				<ui-select ng-model="selected.gist" theme="selectize">
 					<ui-select-match placeholder="select" allow-clear="true">
-									<button class="fa fa-times clear-button" ng-click="clear($event, 'gist')" ng-show="$select.selected.name"></button>
-						{{$select.selected.name}}
+						<button class="fa fa-times clear-button" ng-click="clear($event, 'gist')" ng-show="$select.selected.name"></button> {{$select.selected.name}}
 
 					</ui-select-match>
 					<ui-select-choices group-by="groupDefaultCla" repeat="gist in gists | filter: $select.search" null-option="emptyGist">
-						  <span ng-bind-html="gist.name | highlight: $select.search"></span>
+						<span ng-bind-html="gist.name | highlight: $select.search"></span>
 					</ui-select-choices>
 				</ui-select>
 			</div>
@@ -50,15 +44,14 @@
 		<div class="col-xs-12">
 			<div></div>
 			<div class="form-group has-feedback">
-				<ui-select ng-model="selected.item"  theme="selectize">
+				<ui-select ng-model="selected.item" theme="selectize">
 					<ui-select-match placeholder="select">
-									<button class="fa fa-times clear-button" ng-click="clear($event, 'repo')" ng-show="$select.selected.name"></button>
-									{{$select.selected.full_name || $select.selected.login}}</ui-select-match>
-					<ui-select-choices  group-by="groupOrgs" repeat="item in reposAndOrgs | filter: $select.search | notIn:claRepos | notIn:claOrgs">
-						  <span ng-if="item.full_name" class="octicon" ng-class="{false:'octicon-repo', true:'octicon-repo-forked'}[item.fork]"/>
-						  <span ng-if="item.full_name" ng-bind-html="item.full_name | highlight: $select.search"></span>
-						  <span ng-if="!item.full_name"><img src="{{item.avatar_url}}" alt="" style="width:20px"></span>
-						  <span ng-if="!item.full_name" ng-bind-html="item.login | highlight: $select.search"></span>
+						<button class="fa fa-times clear-button" ng-click="clear($event, 'repo')" ng-show="$select.selected.name"></button> {{$select.selected.full_name || $select.selected.login}}</ui-select-match>
+					<ui-select-choices group-by="groupOrgs" repeat="item in reposAndOrgs | filter: $select.search | notIn:claRepos | notIn:claOrgs">
+						<span ng-if="item.full_name" class="octicon" ng-class="{false:'octicon-repo', true:'octicon-repo-forked'}[item.fork]" />
+						<span ng-if="item.full_name" ng-bind-html="item.full_name | highlight: $select.search"></span>
+						<span ng-if="!item.full_name"><img src="{{item.avatar_url}}" alt="" style="width:20px"></span>
+						<span ng-if="!item.full_name" ng-bind-html="item.login | highlight: $select.search"></span>
 					</ui-select-choices>
 				</ui-select>
 				<span ng-if="selected.item && !isRepo(selected.item)">
@@ -69,8 +62,7 @@
 		</div>
 		<div ng-repeat="error in errorMsg" class="alert alert-danger col-xs-12" role="alert" ng-show="errorMsg.length > 0">
 			<span class="fa fa-warning" aria-hidden="true"></span>
-			<span class="sr-only">Error:</span>
-			{{ error }}
+			<span class="sr-only">Error:</span> {{ error }}
 		</div>
 	</div>
 	<div class="row" style="max-width:400px; position:relative; margin-bottom: 65px;" ng-show="newLink">
@@ -81,12 +73,12 @@
 
 	</div>
 
-<!-- ----------ACTIVATED ORGS---------- -->
+	<!-- ----------ACTIVATED ORGS---------- -->
 	<div ng-if="claOrgs.length > 0" class="row">
 		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Linked Organisations</h4>
 	</div>
 	<div ng-if="claOrgs.length > 0" class="well row" style="padding-top:25px;">
-		  <table  class="table">
+		<table class="table">
 			<tr>
 				<td>
 					<div class="row">
@@ -121,12 +113,12 @@
 		</table>
 	</div>
 
-<!-- ----------ACTIVATED REPOS---------- -->
+	<!-- ----------ACTIVATED REPOS---------- -->
 	<div class="row">
 		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Linked Repositories</h4>
 	</div>
 	<div class="well row" style="padding-top:25px;">
-		  <table  class=" table">
+		<table class=" table">
 			<tr>
 				<td>
 					<div class="row">

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -114,7 +114,7 @@
 			<tr ng-repeat="claOrg in claOrgs | orderBy:'org' ">
 				<td>
 					<div class="row">
-						<settings item="claOrg" repos="repos" user="user" class="settings"></settings>
+						<settings item="claOrg" repos="repos" user="user" class="settings" tooltip-placement="left" tooltip="Excluded Repositories: {{claOrg.excludePattern}}"></settings>
 					</div>
 				</td>
 			</tr>

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -114,7 +114,7 @@
 			<tr ng-repeat="claOrg in claOrgs | orderBy:'org' ">
 				<td>
 					<div class="row">
-						<settings item="claOrg" repos="repos" user="user" class="settings" tooltip-placement="left" tooltip="Excluded Repositories: {{claOrg.excludePattern}}"></settings>
+						<settings item="claOrg" repos="repos" user="user" class="settings"></settings>
 					</div>
 				</td>
 			</tr>

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -61,6 +61,10 @@
 						  <span ng-if="!item.full_name" ng-bind-html="item.login | highlight: $select.search"></span>
 					</ui-select-choices>
 				</ui-select>
+				<span ng-if="selected.item && !isRepo(selected.item)">
+					<div style="margin-bottom: 5px; margin-top: 5px;"><i>Optional:</i> Exclude the following repos from the org</div>
+					<input class="form-control" ng-model="selected.item.excludePattern" placeholder="repo1,repo2,substring1"></input>
+				</span>
 			</div>
 		</div>
 		<div ng-repeat="error in errorMsg" class="alert alert-danger col-xs-12" role="alert" ng-show="errorMsg.length > 0">

--- a/src/client/templates/settings.html
+++ b/src/client/templates/settings.html
@@ -5,7 +5,7 @@
             <a ng-if="item.repo" ng-href="https://github.com/{{ item.owner }}/{{ item.repo }}" target="space">
                 <i class="octicon" ng-class="{false:'octicon-repo', true:'octicon-repo-forked'}[item.fork]"></i> &nbsp; {{ item.owner }} / {{ item.repo }}
             </a>
-            <a ng-if="item.org" ng-href="https://github.com/{{ item.org }}" target="space">
+            <a ng-if="item.org" ng-href="https://github.com/{{ item.org }}" target="space" tooltip-placement="bottom" tooltip="Excluded Repositories: {{item.excludePattern}}">
                 <img src="{{item.avatar_url}}" alt="" class="org">&nbsp; {{ item.org }}
             </a>
         </div>

--- a/src/client/templates/settings.html
+++ b/src/client/templates/settings.html
@@ -5,7 +5,7 @@
             <a ng-if="item.repo" ng-href="https://github.com/{{ item.owner }}/{{ item.repo }}" target="space">
                 <i class="octicon" ng-class="{false:'octicon-repo', true:'octicon-repo-forked'}[item.fork]"></i> &nbsp; {{ item.owner }} / {{ item.repo }}
             </a>
-            <a ng-if="item.org" ng-href="https://github.com/{{ item.org }}" target="space" tooltip-placement="bottom" tooltip="Excluded Repositories: {{item.excludePattern}}">
+            <a ng-if="item.org" ng-href="https://github.com/{{ item.org }}" target="space" tooltip-placement="bottom" tooltip="{{ item.excludePattern ? 'Excluded Repositories: ' + item.excludePattern : 'No Excluded Repositories'}}">
                 <img src="{{item.avatar_url}}" alt="" class="org">&nbsp; {{ item.org }}
             </a>
         </div>

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -225,22 +225,26 @@ module.exports = {
             },
             token: req.args.token || req.user.token
         }, function (err, repos) {
-            if (repos && !repos.message && repos.length > 0) {
-                repos.forEach(function (repo) {
-                    var validateRequest = {
-                        args: {
-                            owner: repo.owner.login,
-                            repo: repo.name,
-                            token: req.args.token || req.user.token
-                        },
-                        user: req.user
-                    };
-                    self.validatePullRequests(validateRequest);
-                });
-            }
-            if (typeof done === 'function') {
-                done(repos.message || err, true);
-            }
+            orgService.get(req.args, function (err, linkedOrg) {
+                if (repos && !repos.message && repos.length > 0) {
+                    repos
+                        .filter(function (repo) { return !linkedOrg.isRepoExcluded(repo.name); })
+                        .forEach(function (repo) {
+                            var validateRequest = {
+                                args: {
+                                    owner: repo.owner.login,
+                                    repo: repo.name,
+                                    token: req.args.token || req.user.token
+                                },
+                                user: req.user
+                            };
+                            self.validatePullRequests(validateRequest);
+                        });
+                }
+                if (typeof done === 'function') {
+                    done(repos.message || err, true);
+                }
+            });
         });
     },
 

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -228,7 +228,7 @@ module.exports = {
             orgService.get(req.args, function (err, linkedOrg) {
                 if (repos && !repos.message && repos.length > 0) {
                     repos
-                        .filter(function (repo) { return !linkedOrg.isRepoExcluded(repo.name); })
+                        .filter(function (repo) { return (linkedOrg.isRepoExcluded === undefined) || !linkedOrg.isRepoExcluded(repo.name); })
                         .forEach(function (repo) {
                             var validateRequest = {
                                 args: {

--- a/src/server/documents/org.js
+++ b/src/server/documents/org.js
@@ -4,8 +4,17 @@ var OrgSchema = mongoose.Schema({
     orgId: String,
     org: String,
     gist: String,
-    token: String
+    token: String,
+    excludePattern: String,
 });
+
+OrgSchema.methods.isRepoExcluded = function (repo) {
+    if (!this.excludePattern || !repo || !repo.includes) {
+        return false;
+    }
+    var patterns = this.excludePattern.split(',');
+    return patterns.filter(function(pattern) { return repo.includes(pattern); }).length > 0;
+};
 
 OrgSchema.index({
     orgId: 1,

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -13,7 +13,8 @@ module.exports = {
             orgId: args.orgId,
             org: args.org,
             gist: args.gist,
-            token: args.token
+            token: args.token,
+            excludePattern: args.excludePattern
         }, function (err, org) {
             done(err, org);
         });

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -52,7 +52,9 @@ module.exports = function (req, res) {
             if (org) {
                 args.token = org.token;
                 args.gist = org.gist; //TODO: Test it!!
-                handleWebHook(args);
+                if (!org.isRepoExcluded(args.repo)) {
+                    handleWebHook(args);
+                }
             } else {
                 args.orgId = undefined;
                 repoService.get(args, function(e, repo){

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -42,7 +42,15 @@ describe('', function () {
                     owner: 'octocat'
                 }
             },
-            orgService: {}
+            orgService: {
+                get: {
+                    repo: 'Hello-World',
+                    owner: 'octocat',
+                    gist: 'https://gist.github.com/aa5a315d61ae9438b18d',
+                    token: 'testToken',
+                    org: 'octocat'
+                }
+            }
         };
         resp = {
             cla: {

--- a/src/tests/server/documents/org.js
+++ b/src/tests/server/documents/org.js
@@ -1,0 +1,32 @@
+var assert = require('assert');
+var Org = require('../../../server/documents/org').Org;
+
+// test data
+var testData = require('../testData').data;
+
+describe('org document', function () {
+  it('should properly work with legacy organisations without excludePattern', function(it_done) {
+    var testOrg = testData.org_from_db;
+    var org = new Org(testOrg);
+
+    assert.equal(org.isRepoExcluded('foo'), false);
+    assert.equal(org.isRepoExcluded('qux'), false);
+    it_done();
+  });
+  it('should properly parse excluded repositories', function (it_done) {
+    var testOrg = testData.org_from_db_with_excluded_patterns;
+    var org = new Org(testOrg);
+
+    assert.equal(org.isRepoExcluded('foo'), true);
+    assert.equal(org.isRepoExcluded('qux'), false);
+    it_done();
+  });
+  it('should properly parse empty exclusion pattern', function (it_done) {
+    var testOrg = testData.org_from_db_with_empty_excluded_patterns;
+    var org = new Org(testOrg);
+
+    assert.equal(org.isRepoExcluded('foo'), false);
+    assert.equal(org.isRepoExcluded('qux'), false);
+    it_done();
+  });
+});

--- a/src/tests/server/testData.js
+++ b/src/tests/server/testData.js
@@ -91,7 +91,8 @@ var testData = {
         'orgId': 1,
         'org': 'octocat',
         'token': 'testToken',
-        'gist': 'https://gist.github.com/aa5a315d61ae9438b18d'
+        'gist': 'https://gist.github.com/aa5a315d61ae9438b18d',
+        'isRepoExcluded': function() { return false; }
     },
 
     ////////////////////////////////////////////

--- a/src/tests/server/testData.js
+++ b/src/tests/server/testData.js
@@ -94,6 +94,22 @@ var testData = {
         'gist': 'https://gist.github.com/aa5a315d61ae9438b18d',
         'isRepoExcluded': function() { return false; }
     },
+    'org_from_db_with_excluded_patterns':
+    {
+        'orgId': 1,
+        'org': 'octocat',
+        'token': 'testToken',
+        'gist': 'https://gist.github.com/aa5a315d61ae9438b18d',
+        'excludePattern': 'foo,bar,baz',
+    },
+    'org_from_db_with_empty_excluded_patterns':
+    {
+        'orgId': 1,
+        'org': 'octocat',
+        'token': 'testToken',
+        'gist': 'https://gist.github.com/aa5a315d61ae9438b18d',
+        'excludePattern': '',
+    },
 
     ////////////////////////////////////////////
     /////////////////// REPO ///////////////////

--- a/src/tests/server/webhooks/pull_request.js
+++ b/src/tests/server/webhooks/pull_request.js
@@ -300,7 +300,8 @@ describe('webhook pull request', function () {
             assert(args.orgId);
             done(null, {
                 org: 'orgOfRequestedRepo',
-				token: 'abc'
+				token: 'abc',
+				isRepoExcluded: function() { return false; }
 			});
         });
 	});


### PR DESCRIPTION
This change adds a field "excludePattern" to the org model, which allows to specify a comma-separated list of repository names or substrings which are matched against the repository of an incoming or rechecked PR. If the string matches against the repo name, the PR is ignored and no
CLA check is done.

Fixes #157.