### PR TITLE
Style changes for CLA signer page.

### DIFF
--- a/src/client/assets/styles/_navbar.scss
+++ b/src/client/assets/styles/_navbar.scss
@@ -9,8 +9,8 @@ $nav-link-padding: 15px 20px 15px 0px;
 
 $grid-float-breakpoint: 100px;
 
-
-$footer-height: 50px;
+$navbar-height: 60px;
+$footer-height: $navbar-height;
 
 .navbar a{
 	text-decoration: none;
@@ -21,7 +21,7 @@ $footer-height: 50px;
 	border-color: white;
 
 	.container-fluid{
-		height: 60px;
+		height: $navbar-height;
 		margin: 0px;
 		padding-top: 15px;
 	}
@@ -59,7 +59,7 @@ $footer-height: 50px;
 	margin-left: 0px;
 }
 .navbar{
-	min-height: 60px;
+	min-height: $navbar-height;
 }
 
 .navbar-center {

--- a/src/client/assets/styles/app.scss
+++ b/src/client/assets/styles/app.scss
@@ -294,12 +294,9 @@ small {
 
 // _cla
 .cla-box {
-  height: 400px;
-  overflow-y: scroll;
   border: 1px solid $gray-light;
-  padding: 10px;
-  margin-top: 15px;
-  margin-bottom: 10px;
+  border-radius: 5px;
+  background-color: $white;
 }
 
 .dots {
@@ -322,10 +319,15 @@ small {
   margin-left: 10px;
 }
 
+.ui-view-content {
+  margin-top: $navbar-height;
+  margin-bottom: $footer-height;
+}
+
 .content-block {
   /*height:100vH;*/
-  padding-top: 150px;
-  margin-bottom: 50px;
+  padding-top: $line-height-computed;
+  margin-bottom: 2 * $line-height-computed;
 }
 
 .content-block .row .right-side {

--- a/src/client/home.html
+++ b/src/client/home.html
@@ -70,7 +70,7 @@
     </div>
   </div>
 
-  <div class="container-fluid" style="margin-bottom:50px;">
+  <div class="container-fluid ui-view-content">
     <div style="margin-left:15px; margin-right: 15px">
         <section ui-view class="col-md-8 col-md-offset-2"></section>
     </div>

--- a/src/client/templates/cla.html
+++ b/src/client/templates/cla.html
@@ -1,22 +1,21 @@
-<div class="row main" style="margin-top: 70px;">
+<div class="row main content-block">
 	<div class="container-fluid">
 
-		<div class="row center-block content-block" ng-show="noLinkedItemError">
+		<div class="row center-block" ng-show="noLinkedItemError">
 			<h1>Error</h1>
 			<p>There is no CLA to sign for {{params.user}}/{{params.repo}}</p>
 			<p>({{noLinkedItemError}})</p>
 		</div>
 
-		<form class="row content-block" ng-hide="!!redirect || noLinkedItemError">
-			<div class="col-md-8 col-md-offset-2" >
+		<form class="row" ng-hide="!!redirect || noLinkedItemError">
 				<h4 ng-hide="signed">Please sign the CLA for {{params.user}}/{{params.repo}}</h4>
 				<h4 ng-show="signed">You have signed the CLA for {{params.user}}/{{params.repo}}</h4>
 				<div class="cla-box well">
 					<div ng-bind-html="cla"></div>
 				</div>
-				<form ng-if="hasCustomFields">
-					<p class="text-center">
-						<button class="btn btn-info sign-btn" ng-show="hasCustomFields && !signed && linkedItem && claText && !user.value" ng-click="signIn()">Sign in with GitHub to agree</button>
+				<form class="row" ng-if="hasCustomFields">
+					<p>
+						<button class="btn btn-info btn-lg" ng-show="hasCustomFields && !signed && linkedItem && claText && !user.value" ng-click="signIn()">Sign in with GitHub to agree</button>
 					</p>
 					<customfield
 						class="form-group"
@@ -35,14 +34,13 @@
 						>
 					</customfield>
 				</form>
-				<p class="text-center" ng-hide="signed"" >
-					<button class="btn btn-info sign-btn" ng-show="hasCustomFields && !signed && linkedItem && claText && user.value" ng-disabled="hasCustomFields && !isValid()" ng-click="agree()">I agree</button>
-					<button class="btn btn-info sign-btn" ng-show="!hasCustomFields && !signed && linkedItem && claText" ng-click="agree()">Sign in with GitHub to agree</button>
+				<p class="row" ng-hide="signed">
+					<button class="btn btn-info btn-lg" ng-show="hasCustomFields && !signed && linkedItem && claText && user.value" ng-disabled="hasCustomFields && !isValid()" ng-click="agree()">I agree</button>
+					<button class="btn btn-info btn-lg" ng-show="!hasCustomFields && !signed && linkedItem && claText" ng-click="agree()">Sign in with GitHub to agree</button>
 				</p>
-			</div>
 		</form>
 
-		<div class="row center-block content-block" ng-show="signed && !!redirect">
+		<div class="row center-block" ng-show="signed && !!redirect">
 			<h3>Thank you {{user.login}}</h3>
 			<h4>for signing the CLA!</h4>
 			</br>


### PR DESCRIPTION
Fixes for https://github.com/cla-assistant/cla-assistant/issues/155 and https://github.com/cla-assistant/cla-assistant/issues/149

1. Use parameters for header and footer sizes.
2. Update cla and home pages to use consistent content whitespace.

**CLA page**

Note: Consistent with other CLA forms (e.g. [Github](https://cla.github.com/agreement), [Google](https://cla.developers.google.com/about/google-individual?csw=1), [jquery](https://js.foundation/CLA/)) the complete CLA is displayed. The width uses standard bootstrap responsive widths, a couple of different widths shown below.

Before
![cla-before-1](https://cloud.githubusercontent.com/assets/1495065/23566052/1818f730-0005-11e7-9752-28df0253c080.jpg)
After
![cla-after-1](https://cloud.githubusercontent.com/assets/1495065/23566059/20738594-0005-11e7-887c-414a55327676.jpg)


Before (wide)
![cla-before-2](https://cloud.githubusercontent.com/assets/1495065/23565957/affad9e8-0004-11e7-8310-90292b7aa072.jpg)
After (wide)
![cla-after-2](https://cloud.githubusercontent.com/assets/1495065/23566001/e22a47d2-0004-11e7-83ef-7107824af27a.jpg)

**Home page**
Note: This fix also makes the initial vertical whitespace on the home page consistent with the cla page.

Before
![home-before](https://cloud.githubusercontent.com/assets/1495065/23566110/5740c104-0005-11e7-921d-e5a338a259fe.jpg)
After
![home-after](https://cloud.githubusercontent.com/assets/1495065/23566152/9a57820c-0005-11e7-9f1f-b01deb5147da.jpg)

