### PR TITLE
Add dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.5
+MAINTAINER GoCD Contributors <go-cd-dev@googlegroups.com>
+
+EXPOSE 5000
+
+COPY . /cla-assistant
+WORKDIR /cla-assistant
+
+RUN \
+  apk add --update nodejs su-exec git curl bzip2 patch make g++ && \
+  addgroup -S cla-assistant && \
+  adduser -S -D -G cla-assistant cla-assistant && \
+  chown -R cla-assistant:cla-assistant /cla-assistant && \
+  su-exec cla-assistant /bin/sh -c 'cd /cla-assistant && npm install && node_modules/grunt-cli/bin/grunt build && rm -rf /home/cla-assistant/.npm .git' && \
+  apk del git curl bzip2 patch make g++
+
+USER cla-assistant
+CMD npm start


### PR DESCRIPTION
I could not find a docker image on dockerhub or a `Dockerfile` to be able to build one. So I've created this for my own use. Would be nice to have this part of the core.

Would you be able to publish (stable) images on dockerhub as well — it's mostly straight forward to do that.