### PR TITLE
Use & concatenation.

### DIFF
--- a/src/server/controller/badge.js
+++ b/src/server/controller/badge.js
@@ -48,11 +48,11 @@ router.all('/readme/badge/:owner/:repo', function (req, res) {
     var colorB = req.query && req.query.colorB ? req.query.colorB : undefined;
     var logo = req.query && req.query.logo ? req.query.logo : undefined;
     var redirect = function (count) {
-        var url = 'https://img.shields.io/badge/CLAs signed-' + count + '-0594c6.svg';
-        url = style ? url + '?style=' + style : url;
-        url = label ? url + '?label=' + label : url;
-        url = colorB ? url + '?colorB=' + colorB : url;
-        url = logo ? url + '?logo=' + logo : url;
+        var url = 'https://img.shields.io/badge/CLAs signed-' + count + '-0594c6.svg?';
+        url = style ? url + '&style=' + style : url;
+        url = label ? url + '&label=' + label : url;
+        url = colorB ? url + '&colorB=' + colorB : url;
+        url = logo ? url + '&logo=' + logo : url;
         res.redirect(url);
     };
     req.args = args;


### PR DESCRIPTION
Following up on #219. Unfortunately I couldn't test this locally.

Now it always appends a '?'. Then followed by the individual key value pairs separated by '&'.