### PR TITLE
Avoid crash when using documentDB to replace mongoDB on Azure.

### DIFF
--- a/src/server/controller/counts.js
+++ b/src/server/controller/counts.js
@@ -94,6 +94,9 @@ router.all('/count/clas', function (req, res) {
             if (err) {
                 logger.info(err);
             }
+            if (!Array.isArray(data)) {
+                data = [];
+            }
             res.set('Content-Type', 'application/json');
             var text = {
                 text: 'There are ' + data.length + ' signed CLAs!'


### PR DESCRIPTION
DocumentDB now supports almost all the MongoDB APIs. However, they are still working on aggregation with group by. So it will return an error with '$group' is not supported'. This is a simple fix to avoid crash when using documentDB. Feel free to give me some feedback. Thank you :)