### PR TITLE
Override org CLA if repo CLA exists

### DIFF
--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -8,9 +8,11 @@
 var isInArray = function(item, items) {
     function check(linkedItem) {
         if (!item.full_name) {
+            // The item is an org
             return linkedItem.org === item.login;
         } else {
-            return (linkedItem.repo === item.name && linkedItem.owner === item.owner.login) || linkedItem.org === item.owner.login;
+            // The item is an repo
+            return linkedItem.repo === item.name && linkedItem.owner === item.owner.login;
         }
     }
     return items.some(check);

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -230,9 +230,21 @@ module.exports = {
         }, function (err, repos) {
             orgService.get(req.args, function (err, linkedOrg) {
                 if (repos && !repos.message && repos.length > 0) {
-                    repos
+                    repoService.all(function (error, linkedRepos) {
+                        if (error) {
+                            log.error(error);
+                            linkedOrg = [];
+                        }
+                        repos
                         .filter(function (repo) {
-                            return (linkedOrg.isRepoExcluded === undefined) || !linkedOrg.isRepoExcluded(repo.name);
+                            // Check whether has been excluded.
+                            if (linkedOrg.isRepoExcluded !== undefined && linkedOrg.isRepoExcluded(repo.name)) {
+                                return false;
+                            }
+                            // Check whether has been overridden.
+                            return !linkedRepos.some(function (linkedRepo) {
+                                return linkedRepo.repoId === repo.id.toString();
+                            });
                         })
                         .forEach(function (repo) {
                             var validateRequest = {
@@ -245,6 +257,7 @@ module.exports = {
                             };
                             self.validatePullRequests(validateRequest);
                         });
+                    });
                 }
                 if (typeof done === 'function') {
                     done(repos.message || err, true);

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -232,8 +232,10 @@ module.exports = {
                 if (repos && !repos.message && repos.length > 0) {
                     repoService.all(function (error, linkedRepos) {
                         if (error) {
-                            log.error(error);
-                            linkedOrg = [];
+                            if (typeof done === 'function') {
+                                done(error.message || error, null);
+                            }
+                            return;
                         }
                         repos
                         .filter(function (repo) {

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -243,7 +243,7 @@ module.exports = {
                             }
                             // Check whether has been overridden.
                             return !linkedRepos.some(function (linkedRepo) {
-                                return linkedRepo.repoId === repo.id.toString();
+                                return linkedRepo.repoId.toString() === repo.id.toString();
                             });
                         })
                         .forEach(function (repo) {

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -208,21 +208,21 @@ module.exports = function () {
                     // could not find the GH Repo
                     deferred.reject(e);
                 } else {
-                    orgService.get({
-                        orgId: ghRepo.owner.id
-                    }, function (err, linkedOrg) {
-                        if (!linkedOrg) {
-                            repoService.get({
-                                repoId: ghRepo.id
-                            }, function (error, linkedRepo) {
-                                if (linkedRepo) {
-                                    deferred.resolve(linkedRepo);
+                    repoService.get({
+                        repoId: ghRepo.id
+                    }, function (error, linkedRepo) {
+                        if (linkedRepo) {
+                            deferred.resolve(linkedRepo);
+                        } else {
+                            orgService.get({
+                                orgId: ghRepo.owner.id
+                            }, function (err, linkedOrg) {
+                                if (linkedOrg) {
+                                    deferred.resolve(linkedOrg);
                                 } else {
                                     deferred.reject(error);
                                 }
                             });
-                        } else {
-                            deferred.resolve(linkedOrg);
                         }
                     });
                 }
@@ -271,12 +271,12 @@ module.exports = function () {
                     query.repoId = repo.repoId;
                     findCla();
                 });
-            } else if (args.orgId) {
-                query.ownerId = args.orgId;
-                query.org_cla = true;
+            } else if (args.repoId) {
+                query.repoId = args.repoId;
                 findCla();
             } else {
-                query.repoId = args.repoId;
+                query.ownerId = args.orgId;
+                query.org_cla = true;
                 findCla();
             }
             return deferred.promise;

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -59,26 +59,26 @@ module.exports = function (req, res) {
 
 
         setTimeout(function () {
-            orgService.get({
-                orgId: args.orgId
-            }, function (err, org) {
-                if (org) {
-                    args.token = org.token;
-                    args.gist = org.gist; //TODO: Test it!!
-                    if (!org.isRepoExcluded(args.repo)) {
-                        repoService.getGHRepo(args, function (err, repo) {
-                            if (repo) {
-                                handleWebHook(args);
-                            }
-                        });
-                    }
-                } else {
+            repoService.get(args, function (e, repo) {
+                if (repo) {
                     args.orgId = undefined;
-                    repoService.get(args, function (e, repo) {
-                        if (repo) {
-                            args.token = repo.token;
-                            args.gist = repo.gist; //TODO: Test it!!
-                            handleWebHook(args);
+                    args.token = repo.token;
+                    args.gist = repo.gist; //TODO: Test it!!
+                    handleWebHook(args);
+                } else {
+                    orgService.get({
+                        orgId: args.orgId
+                    }, function (err, org) {
+                        if (org) {
+                            args.token = org.token;
+                            args.gist = org.gist; //TODO: Test it!!
+                            if (!org.isRepoExcluded(args.repo)) {
+                                repoService.getGHRepo(args, function (err, repo) {
+                                    if (repo) {
+                                        handleWebHook(args);
+                                    }
+                                });
+                            }
                         }
                     });
                 }

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -85,6 +85,7 @@ describe('', function () {
             },
             repoService: {
                 get: JSON.parse(JSON.stringify(testData.repo_from_db)), //clone object
+                all: JSON.parse(JSON.stringify(testData.repo_from_db))
             },
             orgService: {
                 get: JSON.parse(JSON.stringify(testData.org_from_db)), //clone object
@@ -100,7 +101,8 @@ describe('', function () {
                 user: null
             },
             repoService: {
-                get: null
+                get: null,
+                all: null
             },
             orgService: {
                 get: null
@@ -403,6 +405,9 @@ describe('', function () {
                 cb(null, true);
             });
             sinon.stub(prService, 'editComment', function () { });
+            sinon.stub(repo_service, 'all', function (cb) {
+                cb(error.repoService.all, [resp.repoService.all]);
+            });
         });
 
         afterEach(function () {
@@ -410,6 +415,7 @@ describe('', function () {
             cla.sign.restore();
             prService.editComment.restore();
             statusService.update.restore();
+            repo_service.all.restore();
         });
 
         it('should call cla service on sign', function (it_done) {

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -1060,6 +1060,15 @@ describe('', function () {
                 it_done();
             });
         });
+
+        it('should NOT validate when querying repo collection throw error', function (it_done) {
+            error.repoService.all = 'any error of querying repo collection';
+            cla_api.validateOrgPullRequests(req, function (err) {
+                assert.equal(!!err, true);
+                assert(!cla.check.called);
+                it_done();
+            });
+        });
     });
 
     describe('cla:getLinkedItem', function () {

--- a/src/tests/server/webhooks/pull_request.js
+++ b/src/tests/server/webhooks/pull_request.js
@@ -417,9 +417,21 @@ describe('webhook pull request', function () {
 	// 	assert.equal(cla.check.called, true);
 	// });
 
-	it('should try to access GH repo if org is known', function (it_done) {
-		orgService.get.restore();
-		sinon.stub(orgService, 'get', function (args, done) {
+	it('should NOT try to access org cla if repo cla is exist', function (it_done) {
+		pull_request(test_req, res);
+		this.timeout(20);
+		setTimeout(function () {
+			assert.equal(repoService.get.called, true);
+			assert.equal(orgService.get.called, false);
+			assert.equal(repoService.getPRCommitters.called, true);
+			assert.equal(cla.check.called, true);
+			it_done();
+		}, 8);
+	});
+
+	it('should try to access org cla if repo cla is NOT exist', function (it_done) {
+		repoService.get.restore();
+		sinon.stub(repoService, 'get', function (args, done) {
 			done(null, null);
 		});
 
@@ -436,7 +448,11 @@ describe('webhook pull request', function () {
 
 	it('should update status of PR even if org is unknown but from known repo', function (it_done) {
 		repoService.getGHRepo.restore();
+		repoService.get.restore();
 		sinon.stub(repoService, 'getGHRepo', function (args, done) {
+			done(null, null);
+		});
+		sinon.stub(repoService, 'get', function (args, done) {
 			done(null, null);
 		});
 
@@ -445,7 +461,7 @@ describe('webhook pull request', function () {
 		setTimeout(function () {
 			assert.equal(repoService.getGHRepo.called, true);
 			assert.equal(orgService.get.called, true);
-			assert.equal(repoService.get.called, false);
+			assert.equal(repoService.get.called, true);
 			assert.equal(repoService.getPRCommitters.called, false);
 			assert.equal(cla.check.called, false);
 			it_done();


### PR DESCRIPTION
In a complex company, one scenario is that a few repos need different CLA from the org CLA. So I think it's good to override org CLA if a repo CLA exist. Any thought?