### PR TITLE
Cannot remove repo webhook after unlinking a repo.

### DIFF
--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -328,7 +328,7 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                     org: linkedItem.org
                 } : {
                     repo: linkedItem.repo,
-                    user: linkedItem.owner
+                    owner: linkedItem.owner
                 };
                 $RPCService.call('webhook', 'remove', arg, function () {});
             };

--- a/src/tests/client/controller/HomeCtrl.spec.js
+++ b/src/tests/client/controller/HomeCtrl.spec.js
@@ -799,7 +799,7 @@ describe('Home Controller', function() {
 
         ($RPCService.call.calledWithMatch('webhook', 'remove', {
             repo: 'myRepo',
-            user: 'login'
+            owner: 'login'
         })).should.be.equal(true);
         (homeCtrl.scope.errorMsg[0]).should.not.be.equal('This repository is already set up.');
     });


### PR DESCRIPTION
One the server-side, the function ```extractGithubArgs (args)```  [here](https://github.com/cla-assistant/cla-assistant/blob/master/src/server/api/webhook.js#L106) uses 'owner' while on the client side using 'user' [here](https://github.com/cla-assistant/cla-assistant/blob/master/src/client/controller/home.js#L331). 