### PR TITLE
Sign only once when multiple orgs or repos lined with the same gist

### DIFF
--- a/src/client/controller/cla.js
+++ b/src/client/controller/cla.js
@@ -59,7 +59,7 @@ module.controller('ClaController', ['$window', '$scope', '$stateParams', '$RAW',
 			}
 
 			function isSharedSignature(cla) {
-				return !cla.owner;
+				return cla && !cla.owner;
 			}
 
 			function getCLA() {

--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -364,7 +364,8 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                     repo: $scope.selected.item.name,
                     owner: $scope.selected.item.owner.login,
                     repoId: $scope.selected.item.id,
-                    gist: $scope.selected.gist.url
+                    gist: $scope.selected.gist.url,
+                    sharedGist: $scope.selected.sharedGist
                 };
                 newClaRepo = mixRepoData(newClaRepo);
                 return linkItem('repo', newClaRepo);
@@ -375,7 +376,8 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                     orgId: $scope.selected.item.id,
                     org: $scope.selected.item.login,
                     gist: $scope.selected.gist.url,
-                    excludePattern: $scope.selected.item.excludePattern
+                    excludePattern: $scope.selected.item.excludePattern,
+                    sharedGist: $scope.selected.sharedGist
                 };
                 mixOrgData(newClaOrg);
                 return linkItem('org', newClaOrg);

--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -261,6 +261,14 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                 });
             };
 
+            $scope.gistShareInfo = function () {
+                $modal.open({
+                    templateUrl: '/modals/templates/info_share_gist.html',
+                    controller: 'InfoCtrl',
+                    windowClass: 'howto'
+                });
+            };
+
             $scope.getDefaultClaFiles = function () {
                 var promise = $RAW.get('/static/cla-assistant.json');
                 promise.then(function (data) {

--- a/src/client/controller/settings.js
+++ b/src/client/controller/settings.js
@@ -51,7 +51,8 @@ module.controller('SettingsCtrl', ['$rootScope', '$scope', '$stateParams', '$HUB
                 gist: {
                     gist_url: linkedItem.gist,
                     gist_version: gist_version
-                }
+                },
+                sharedGist: linkedItem.sharedGist
             }, cb);
         };
 

--- a/src/client/modals/templates/info_gist.html
+++ b/src/client/modals/templates/info_gist.html
@@ -10,8 +10,8 @@
 
     <div class="free-space">
         <h4>What happens if I edit the Gist file?</h4>
-        <div>  
-        	CLA assistant will always show you the current version of your Gist file. Users who accept your CLA sign the current version. If you change the content of your CLA, each contributor has to accept the new version when they create a new pull request. 
+        <div>
+        	CLA assistant will always show you the current version of your Gist file. Users who accept your CLA sign the current version. If you change the content of your CLA, each contributor has to accept the new version when they create a new pull request.
         </div>
     </div>
 

--- a/src/client/modals/templates/info_share_gist.html
+++ b/src/client/modals/templates/info_share_gist.html
@@ -1,0 +1,21 @@
+<div class="modal-body modal-primary">
+    <div ng-click="cancel()" class="fa fa-times close-button"></div>
+    <div class="free-space">
+        <h4>What happens if I choose to share the gist with multiple repos or orgs?</h4>
+        <div>
+            Contributors will simply need to sign only once for any of the repos or orgs linked with the same shared gist.
+        </div>
+    </div>
+    <div class="free-space">
+        <h4>Are previous CLA signatures still valid after I choose to share the gist with multiple repos or orgs?</h4>
+        <div>
+            Yes, but the scope of the previous signatures are still limited to the previous repo or org.
+        </div>
+    </div>
+    <div class="free-space">
+        <h4>What happens if I uncheck the box and choose NOT to share the gist any more?</h4>
+        <div>
+            Previous contributors that have signed the shared gist will have to sign again.
+        </div>
+    </div>
+</div>

--- a/src/client/templates/cla.html
+++ b/src/client/templates/cla.html
@@ -13,6 +13,9 @@
 				<div class="cla-box well">
 					<div ng-bind-html="cla"></div>
 				</div>
+				<div class="row" ng-if="showSharedGistMsg()" style="font-size:18px; margin:10px">
+					<em>This CLA applies to multiple repos or orgs.</em>
+				</div>
 				<form class="row" ng-if="hasCustomFields">
 					<p>
 						<button class="btn btn-info btn-lg" ng-show="hasCustomFields && !signed && linkedItem && claText && !user.value" ng-click="signIn()">Sign in with GitHub to agree</button>

--- a/src/client/templates/cla.html
+++ b/src/client/templates/cla.html
@@ -13,7 +13,7 @@
 				<div class="cla-box well">
 					<div ng-bind-html="cla"></div>
 				</div>
-				<div class="row" ng-if="showSharedGistMsg()" style="font-size:18px; margin:10px">
+				<div class="h4" ng-if="showSharedGistMsg()">
 					<em>This CLA applies to multiple repos or orgs.</em>
 				</div>
 				<form class="row" ng-if="hasCustomFields">

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -32,6 +32,9 @@
 			<div style="margin-bottom:10px">- or -</div>
 			<div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
 			<input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>" required></input>
+			<div style="margin-top: 15px;">
+				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false">&nbsp;Share the gist with multiple repos or orgs</input>
+  		</div>
 		</div>
 
 		<h5 ng-if="!user.value.org_admin" class="col-xs-12 link-topic-2">
@@ -88,11 +91,14 @@
 						<div class="col-sm-3 col-lg-2">
 							CLA
 						</div>
-						<div class="col-lg-3 hidden-xs hidden-sm hidden-md">
+						<div class="col-lg-2 hidden-xs hidden-sm hidden-md">
 							Gist
 						</div>
 						<div class="col-sm-2 col-lg-2">
 							Last updated
+						</div>
+						<div class="col-sm-1 col-lg-1">
+							Shared Gist
 						</div>
 						<div class="col-sm-2 col-lg-1 text">
 							Contributors
@@ -128,11 +134,14 @@
 						<div class="col-sm-3 col-lg-2">
 							CLA
 						</div>
-						<div class="col-lg-3 hidden-xs hidden-sm hidden-md">
+						<div class="col-lg-2 hidden-xs hidden-sm hidden-md">
 							Gist
 						</div>
 						<div class="col-sm-2 col-lg-2">
 							Last updated
+						</div>
+						<div class="col-sm-1 col-lg-1">
+							Shared Gist
 						</div>
 						<div class="col-sm-2 col-lg-1 text">
 							Contributors

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -33,8 +33,9 @@
 			<div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
 			<input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>" required></input>
 			<div style="margin-top: 15px;">
-				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false">&nbsp;Share the gist with multiple repos or orgs</input>
-  		</div>
+				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false">&nbsp;Share the Gist &nbsp;</input>
+				<span class="clickable" ng-click="gistShareInfo()" style="font-size:12px; text-decoration:underline">(want to share?)</span>
+  			</div>
 		</div>
 
 		<h5 ng-if="!user.value.org_admin" class="col-xs-12 link-topic-2">

--- a/src/client/templates/settings.html
+++ b/src/client/templates/settings.html
@@ -17,7 +17,7 @@
         </div>
     </div>
 
-    <div class="col-xs-12 col-lg-3 hidden-xs hidden-sm hidden-md text">
+    <div class="col-xs-12 col-lg-2 hidden-xs hidden-sm hidden-md text">
         <a ng-href="{{gist.html_url}}" target="space">{{gist.html_url}}</a>
     </div>
 
@@ -25,7 +25,11 @@
         {{gist.updated_at | date:'longDate'}}
     </div>
 
-    <div class="col-xs-4 col-sm-2 col-lg-1" style="text-align:center; text-decoration: underline;">
+    <div class="col-xs-12 col-sm-1 col-lg-1 text">
+        {{ item.sharedGist ? 'Yes' : 'No' }}
+    </div>
+
+    <div class="col-xs-4 col-sm-1 col-lg-1" style="text-align:center; text-decoration: underline;">
         <a ng-click="getReport(item);" class="clickable">{{signatures.value.length}}</a>
     </div>
 

--- a/src/server/documents/cla.js
+++ b/src/server/documents/cla.js
@@ -11,10 +11,7 @@ var CLASchema = mongoose.Schema({
     ownerId: String,
     repo: String,
     repoId: String,
-    org_cla: {
-        type: Boolean,
-        default: false
-    },
+    org_cla: Boolean,
     user: String,
     userId: String,
 });

--- a/src/server/documents/org.js
+++ b/src/server/documents/org.js
@@ -7,6 +7,7 @@ var OrgSchema = mongoose.Schema({
     gist: String,
     token: String,
     excludePattern: String,
+    sharedGist: Boolean
 });
 
 OrgSchema.methods.isRepoExcluded = function(repo) {

--- a/src/server/documents/repo.js
+++ b/src/server/documents/repo.js
@@ -6,7 +6,8 @@ var RepoSchema = mongoose.Schema({
     repo: String,
     owner: String,
     gist: String,
-    token: String
+    token: String,
+    sharedGist: Boolean
 });
 
 RepoSchema.index({

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -14,7 +14,8 @@ module.exports = {
             org: args.org,
             gist: args.gist,
             token: args.token,
-            excludePattern: args.excludePattern
+            excludePattern: args.excludePattern,
+            sharedGist: !!args.sharedGist
         }, function (err, org) {
             done(err, org);
         });
@@ -26,6 +27,10 @@ module.exports = {
 
     getMultiple: function (args, done) {
         Org.find({ orgId: { $in: args.orgId } }, done);
+    },
+
+    getOrgWithSharedGist: function (gist, done) {
+        Org.find({ gist: gist, sharedGist: true }, done);
     },
 
     remove: function (args, done) {

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -94,7 +94,8 @@ module.exports = {
             owner: args.owner,
             repoId: args.repoId,
             gist: args.gist,
-            token: args.token
+            token: args.token,
+            sharedGist: !!args.sharedGist
         }, function (err, repo) {
             done(err, repo);
         });
@@ -123,6 +124,10 @@ module.exports = {
         Repo.find({
             owner: owner
         }, done);
+    },
+
+    getRepoWithSharedGist: function (gist, done) {
+        Repo.find({ gist: gist, sharedGist: true }, done);
     },
 
     update: function (args, done) {


### PR DESCRIPTION
One scenario I still not sure and want to discuss. When a admin want to try the new feature and re-link a repo with the same gist but mark it as a shared gist with other repos. Do we need contributors who have already signed the repo gist to sign again? 

UI:
<img width="557" alt="screen shot 2017-07-20 at 1 15 59 am" src="https://user-images.githubusercontent.com/20408623/28450382-e921b192-6d9b-11e7-8af4-972f52663f87.png">
<img width="1025" alt="screen shot 2017-07-20 at 10 37 44 pm" src="https://user-images.githubusercontent.com/20408623/28450426-26e82aec-6d9c-11e7-99b0-5667dd146f10.png">
