### PR TITLE
Add FAQ pointing to contributoragreements.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ We store all the data in a MongoDB hosted by [mLab](https://mlab.com/).
 #### Where can I see the list of signees? Is there a way to import/export the signee data?
 You can see the list of signees on the user interface. There is also a possibility for you to export the list as a .csv file.
 
+#### What should my Contributor License Agreement say?
+We're no lawyers, but we can suggest using http://contributoragreements.org/ for a fill-in-the-blank approach to creating a CLA tailored to your needs.
+
 #### Who can I contact for help?
 In case of problems or any further questions, please open an issue in GitHub. We always appreciate helpful tips and support for the project.
 


### PR DESCRIPTION
Users of the CLA-Agreement tool may wonder what text to use as part of the CLA.  This pull request adds a FAQ entry pointing to http://contributoragreements.org/ for a fill-in-the-blank approach to creating the CLA text.