### PR TITLE
Multiple changes to enable bigger repo scale

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3027,14 +3027,6 @@
                         }
                     }
                 },
-                "string_decoder": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
@@ -3043,6 +3035,14 @@
                         "code-point-at": "1.1.0",
                         "is-fullwidth-code-point": "1.0.0",
                         "strip-ansi": "3.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.0.1"
                     }
                 },
                 "stringstream": {
@@ -4498,6 +4498,11 @@
             "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
             "dev": true
         },
+        "isemail": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+            "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+        },
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4589,6 +4594,22 @@
                 }
             }
         },
+        "items": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+            "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg="
+        },
+        "joi": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+            "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+            "requires": {
+                "hoek": "4.2.0",
+                "isemail": "2.2.1",
+                "items": "2.1.1",
+                "topo": "2.0.2"
+            }
+        },
         "js-base64": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
@@ -4665,7 +4686,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true,
             "requires": {
                 "jsonify": "0.0.0"
             }
@@ -4693,8 +4713,7 @@
         "jsonify": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsonpointer": {
             "version": "4.0.1",
@@ -6696,15 +6715,6 @@
                 "throttleit": "1.0.0"
             }
         },
-        "require_optional": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-            "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-            "requires": {
-                "resolve-from": "2.0.0",
-                "semver": "5.4.1"
-            }
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6731,6 +6741,15 @@
                     "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
                     "dev": true
                 }
+            }
+        },
+        "require_optional": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+            "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+            "requires": {
+                "resolve-from": "2.0.0",
+                "semver": "5.4.1"
             }
         },
         "requires-port": {
@@ -7435,14 +7454,6 @@
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
-        "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-            "requires": {
-                "safe-buffer": "5.1.1"
-            }
-        },
         "string-length": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7459,6 +7470,14 @@
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "requires": {
+                "safe-buffer": "5.1.1"
             }
         },
         "stringstream": {
@@ -7804,6 +7823,14 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
             "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
+        },
+        "topo": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+            "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+            "requires": {
+                "hoek": "4.2.0"
+            }
         },
         "tough-cookie": {
             "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express-session": "^1.15.6",
     "github": "^11.0.0",
     "glob": "^7.0.5",
+    "joi": "^10.6.0",
     "memory-cache": "^0.2.0",
     "merge": "^1.2.0",
     "mongoose": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "glob": "^7.0.5",
     "joi": "^10.6.0",
     "json-stable-stringify": "^1.0.1",
+    "lodash": "^4.17.4",
     "memory-cache": "^0.2.0",
     "merge": "^1.2.0",
     "mongoose": "^4.12.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "github": "^11.0.0",
     "glob": "^7.0.5",
     "joi": "^10.6.0",
+    "json-stable-stringify": "^1.0.1",
     "memory-cache": "^0.2.0",
     "merge": "^1.2.0",
     "mongoose": "^4.12.2",

--- a/src/client/controller/cla.js
+++ b/src/client/controller/cla.js
@@ -46,7 +46,8 @@ module.controller('ClaController', ['$window', '$scope', '$stateParams', '$RAW',
 			function getSignedValues() {
 				$RPCService.call('cla', 'getLastSignature', {
 					repo: $stateParams.repo,
-					owner: $stateParams.user
+					owner: $stateParams.user,
+					number: $stateParams.pullRequest
 				}, function (err, res) {
 					if ($scope.hasCustomFields && res && res.value && res.value.custom_fields) {
 						var customFields = JSON.parse(res.value.custom_fields);
@@ -82,7 +83,8 @@ module.controller('ClaController', ['$window', '$scope', '$stateParams', '$RAW',
 			function checkCLA() {
 				return $RPCService.call('cla', 'check', {
 					repo: $stateParams.repo,
-					owner: $stateParams.user
+					owner: $stateParams.user,
+					number: $stateParams.pullRequest
 				}, function (err, signed) {
 					if (!err && signed.value) {
 						$scope.signed = true;

--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -384,7 +384,9 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                 owner: $scope.selected.item.owner.login,
                 repoId: $scope.selected.item.id,
                 gist: $scope.selected.gist.url,
-                sharedGist: $scope.selected.sharedGist
+                sharedGist: $scope.selected.sharedGist,
+                minFileChanges: $scope.selected.minFileChanges,
+                minCodeChanges: $scope.selected.minCodeChanges
             };
             newClaRepo = mixRepoData(newClaRepo);
             return linkItem('repo', newClaRepo);
@@ -396,7 +398,9 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$document', '$HUB', '$RP
                 org: $scope.selected.item.login,
                 gist: $scope.selected.gist.url,
                 excludePattern: $scope.selected.item.excludePattern,
-                sharedGist: $scope.selected.sharedGist
+                sharedGist: $scope.selected.sharedGist,
+                minFileChanges: $scope.selected.minFileChanges,
+                minCodeChanges: $scope.selected.minCodeChanges
             };
             mixOrgData(newClaOrg);
             return linkItem('org', newClaOrg);

--- a/src/client/controller/settings.js
+++ b/src/client/controller/settings.js
@@ -142,6 +142,9 @@ module.controller('SettingsCtrl', ['$rootScope', '$scope', '$stateParams', '$HUB
         };
 
         $scope.getGistName = function() {
+            if (!$scope.item.gist) {
+                return '';
+            }
             $scope.gist.fileName = $scope.gist.fileName ? $scope.gist.fileName : utils.getGistAttribute($scope.gist, 'filename');
             return $scope.gist.fileName;
         };
@@ -172,7 +175,7 @@ module.controller('SettingsCtrl', ['$rootScope', '$scope', '$stateParams', '$HUB
         };
 
         $scope.isLinkActive = function() {
-            return !$scope.loading && $scope.valid.gist && $scope.valid.webhook;
+            return (!$scope.loading && $scope.valid.gist && $scope.valid.webhook) || !$scope.item.gist;
         };
 
         $scope.renderHtml = function(html_code) {

--- a/src/client/templates/customField.html
+++ b/src/client/templates/customField.html
@@ -1,4 +1,4 @@
-<div ng-if="type != 'checkbox' && type != 'textarea' && !type.enum" title="{{description}}">
+<div ng-if="type != 'checkbox' && type != 'textarea' && !type.enum && type !== 'readonly'" title="{{description}}">
     <label ng-hide="type === 'hidden'" ng-class="{'required': required}">{{title || name}} </label>
     <div ng-show="description && type !== 'hidden'" class="description">({{description}})</div>
     <input ng-disabled="!logged || signed" class="form-control" ng-model="value[name]" title="{{description}}" type="{{type}}"
@@ -23,4 +23,7 @@
         <input ng-disabled="!logged || signed" ng-model="value[name]" name="{{name}}" title="{{description}}" type="radio" value="{{prop}}"
         /> {{prop}}
     </div>
+</div>
+<div ng-if="type === 'readonly'">
+    <label ng-show="value[name]">{{value[name]}}<label>
 </div>

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -5,82 +5,80 @@
 <!-- ----------ACTIVATE a CLA---------- -->
 <div id="activated_cla" ng-show="user.value.admin" class="row content-block">
 
-    <div class="row" style="margin-bottom: 65px; margin-top: 15px; padding-left:0px" ng-hide="newLink">
-        <button class="btn btn-info" ng-click="newLink = !newLink" ng-init="newLink=false" style="font-size: 18px; font-weight: 200">Create new link</button>
-    </div>
-    <div class="row" ng-show="newLink">
-        <h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Create new link</h4>
-    </div>
+	<div class="row" style="margin-bottom: 65px; margin-top: 15px; padding-left:0px" ng-hide="newLink">
+		<button class="btn btn-info" ng-click="newLink = !newLink" ng-init="newLink=false" style="font-size: 18px; font-weight: 200">Configure CLA</button>
+	</div>
+	<div class="row" ng-show="newLink">
+		<h4 class="col-xs-12" style="margin: 25px 0; padding-left: 0;">Configure CLA</h4>
+	</div>
 
-    <div class="well row" ng-show="newLink" style="max-width:400px; position:relative;">
-        <div ng-click="newLink = !newLink" class="fa fa-times close-button" style="position:absolute; right:20px"></div>
-
-        <h5 class="link-topic-1">
-            <span class="link-topic-number">1</span>&nbsp;Choose a CLA
-        </h5>
-        <div class="col-xs-12">
-            <div style="margin-bottom: 5px;">Select from Gist &nbsp;
-                <span class="clickable" ng-click="info()" style="font-size:12px; text-decoration:underline">(don't have one?)</span>
-            </div>
-            <div class="form-group has-feedback" style="margin-bottom: 10px;">
-                <ui-select ng-model="selected.gist" theme="selectize">
-                    <ui-select-match placeholder="select" allow-clear="true">
-                        <button class="fa fa-times clear-button" ng-click="clear($event, 'gist')" ng-show="$select.selected.name"></button> {{$select.selected.name}}
-
-                    </ui-select-match>
-                    <ui-select-choices group-by="groupDefaultCla" repeat="gist in gists | filter: $select.search" null-option="emptyGist">
-                        <span ng-bind-html="gist.name | highlight: $select.search"></span>
-                    </ui-select-choices>
-                </ui-select>
-            </div>
-            <div style="margin-bottom:10px">- or -</div>
-            <div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
-            <input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>"
-                required></input>
-            <div style="margin-top: 15px;">
-                <input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false">&nbsp;Share the Gist &nbsp;</input>
-                <span class="clickable" ng-click="gistShareInfo()" style="font-size:12px; text-decoration:underline">(want to share?)</span>
-            </div>
-        </div>
-
-        <h5 ng-if="!user.value.org_admin" class="col-xs-12 link-topic-2">
-            <span class="link-topic-number">2</span>&nbsp;Choose a repository
+	<div class="well row" ng-show="newLink" style="max-width:400px; position:relative;">
+		<div ng-click="newLink = !newLink" class="fa fa-times close-button" style="position:absolute; right:20px"></div>
+		<h5 ng-if="!user.value.org_admin" class="col-xs-12 link-topic-2">
+			<span class="link-topic-number">1</span>&nbsp;Choose a repository
             <span class="clickable" ng-click="addScope()" style="font-size:12px; text-decoration:underline">(want to link an org?)</span>
-        </h5>
-        <h5 ng-if="user.value.org_admin" class="col-xs-12 link-topic-2">
-            <span class="link-topic-number">2</span>&nbsp;Choose an org or a repo
-        </h5>
-        <div class="col-xs-12">
-            <div></div>
-            <div class="form-group has-feedback">
-                <ui-select ng-model="selected.item" theme="selectize">
-                    <ui-select-match placeholder="select">
-                        <button class="fa fa-times clear-button" ng-click="clear($event, 'repo')" ng-show="$select.selected.name"></button> {{$select.selected.full_name || $select.selected.login}}</ui-select-match>
-                    <ui-select-choices group-by="groupOrgs" repeat="item in reposAndOrgs | filter: $select.search | notIn:claRepos | notIn:claOrgs">
-                        <span ng-if="item.full_name" class="octicon" ng-class="{false:'octicon-repo', true:'octicon-repo-forked'}[item.fork]" />
-                        <span ng-if="item.full_name" ng-bind-html="item.full_name | highlight: $select.search"></span>
-                        <span ng-if="!item.full_name">
+		</h5>
+		<h5 ng-if="user.value.org_admin" class="col-xs-12 link-topic-2">
+			<span class="link-topic-number">1</span>&nbsp;Choose an org or a repo
+		</h5>
+		<div class="col-xs-12">
+			<div></div>
+			<div class="form-group has-feedback">
+				<ui-select ng-model="selected.item" theme="selectize">
+					<ui-select-match placeholder="select">
+						<button class="fa fa-times clear-button" ng-click="clear($event, 'repo')" ng-show="$select.selected.name"></button> {{$select.selected.full_name || $select.selected.login}}</ui-select-match>
+					<ui-select-choices group-by="groupOrgs" repeat="item in reposAndOrgs | filter: $select.search | notIn:claRepos | notIn:claOrgs">
+						<span ng-if="item.full_name" class="octicon" ng-class="{false:'octicon-repo', true:'octicon-repo-forked'}[item.fork]" />
+						<span ng-if="item.full_name" ng-bind-html="item.full_name | highlight: $select.search"></span>
+						<span ng-if="!item.full_name">
                             <img src="{{item.avatarUrl}}" alt="" style="width:20px">
                         </span>
-                        <span ng-if="!item.full_name" ng-bind-html="item.login | highlight: $select.search"></span>
-                    </ui-select-choices>
-                </ui-select>
-                <span ng-if="selected.item && !isRepo(selected.item)">
-                    <div style="margin-bottom: 5px; margin-top: 5px;">
+						<span ng-if="!item.full_name" ng-bind-html="item.login | highlight: $select.search"></span>
+					</ui-select-choices>
+				</ui-select>
+				<span ng-if="selected.item && !isRepo(selected.item)">
+					<div style="margin-bottom: 5px; margin-top: 5px;">
                         <i>Optional:</i> Exclude the following repos from the org</div>
-                    <input class="form-control" ng-model="selected.item.excludePattern" placeholder="repo1,repo2,substring1"></input>
-                </span>
-            </div>
-        </div>
-        <div ng-repeat="error in errorMsg" class="alert alert-danger col-xs-12" role="alert" ng-show="errorMsg.length > 0">
-            <span class="fa fa-warning" aria-hidden="true"></span>
-            <span class="sr-only">Error:</span> {{ error }}
-        </div>
-    </div>
-    <div class="row" style="max-width:400px; position:relative; margin-bottom: 65px;" ng-show="newLink">
-        <button class="btn btn-info col-xs-12" ng-click="linkCla()" ng-disabled="!selected.item || !isValid(selected.gist.url)" style="height: 45px">
-            <img src="/assets/images/link_button.svg" style="height: 18px"> LINK
-        </button>
+					<input class="form-control" ng-model="selected.item.excludePattern" placeholder="repo1,repo2,substring1"></input>
+				</span>
+			</div>
+		</div>
+		<h5 class="link-topic-1">
+			<span class="link-topic-number">2</span>&nbsp;Choose a CLA
+		</h5>
+		<div class="col-xs-12">
+			<div style="margin-bottom: 5px;">Select from Gist &nbsp;
+				<span class="clickable" ng-click="info()" style="font-size:12px; text-decoration:underline">(don't have one?)</span>
+			</div>
+			<div class="form-group has-feedback" style="margin-bottom: 10px;">
+				<ui-select ng-model="selected.gist" theme="selectize">
+					<ui-select-match placeholder="select" allow-clear="true">
+						<button class="fa fa-times clear-button" ng-click="clear($event, 'gist')" ng-show="$select.selected.name"></button> {{$select.selected.name}}
+
+					</ui-select-match>
+					<ui-select-choices group-by="groupDefaultCla" repeat="gist in gists | filter: $select.search" null-option="emptyGist">
+						<span ng-bind-html="gist.name | highlight: $select.search"></span>
+					</ui-select-choices>
+				</ui-select>
+			</div>
+			<div style="margin-bottom:10px">- or -</div>
+			<div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
+			<input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>" required></input>
+			<div style="margin-top: 15px;">
+				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false" ng-disabled="selected.gist && !selected.gist.url">&nbsp;Share the Gist &nbsp;</input>
+				<span class="clickable" ng-click="gistShareInfo()" style="font-size:12px; text-decoration:underline">(want to share?)</span>
+			</div>
+		</div>
+
+		<div ng-repeat="error in errorMsg" class="alert alert-danger col-xs-12" role="alert" ng-show="errorMsg.length > 0">
+			<span class="fa fa-warning" aria-hidden="true"></span>
+			<span class="sr-only">Error:</span> {{ error }}
+		</div>
+	</div>
+	<div class="row" style="max-width:400px; position:relative; margin-bottom: 65px;" ng-show="newLink">
+		<button class="btn btn-info col-xs-12" ng-click="linkCla()" ng-disabled="!isComplete()" style="height: 45px">
+			<img src="/assets/images/link_button.svg" style="height: 18px"> LINK
+		</button>
 
     </div>
 

--- a/src/client/templates/home.html
+++ b/src/client/templates/home.html
@@ -16,7 +16,7 @@
 		<div ng-click="newLink = !newLink" class="fa fa-times close-button" style="position:absolute; right:20px"></div>
 		<h5 ng-if="!user.value.org_admin" class="col-xs-12 link-topic-2">
 			<span class="link-topic-number">1</span>&nbsp;Choose a repository
-            <span class="clickable" ng-click="addScope()" style="font-size:12px; text-decoration:underline">(want to link an org?)</span>
+      		<span class="clickable" ng-click="addScope()" style="font-size:12px; text-decoration:underline">(want to link an org?)</span>
 		</h5>
 		<h5 ng-if="user.value.org_admin" class="col-xs-12 link-topic-2">
 			<span class="link-topic-number">1</span>&nbsp;Choose an org or a repo
@@ -64,11 +64,26 @@
 			<div style="margin-bottom:10px">- or -</div>
 			<div style="margin-bottom: 5px;">Paste a URL from a Gist</div>
 			<input ng-disabled="selected.gist.name" class="form-control" ng-model="selected.gist.url" placeholder="https://gist.github.com/<your cla gist id>" required></input>
-			<div style="margin-top: 15px;">
+			<div style="margin-bottom: 15px; margin-top: 15px;">
 				<input type="checkbox" ng-model="selected.sharedGist" ng-init="selected.sharedGist = false" ng-disabled="selected.gist && !selected.gist.url">&nbsp;Share the Gist &nbsp;</input>
 				<span class="clickable" ng-click="gistShareInfo()" style="font-size:12px; text-decoration:underline">(want to share?)</span>
 			</div>
 		</div>
+		<h5 class="link-topic-1">
+			<span class="link-topic-number">3</span>&nbsp;CLA Requirement Settings (Optional)
+		</h5>
+		<div class="col-xs-12">
+			<div class="form-group">
+				<div style="margin-bottom:5px">Minimum File Number Changes</div>
+				<input class="form-control" type="number" ng-model="selected.minFileChanges" ng-disabled="selected.gist && !selected.gist.url" placeholder="Number"></input>
+			</div>
+			<div style="margin-bottom:10px">- or -</div>
+			<div class="form-group">
+				<div style="margin-bottom:5px;">Minimum Line Number Changes</div>
+				<input class="form-control" type="number" ng-model="selected.minCodeChanges" ng-disabled="selected.gist && !selected.gist.url" placeholder="Number"></input>
+			</div>
+		</div>
+
 
 		<div ng-repeat="error in errorMsg" class="alert alert-danger col-xs-12" role="alert" ng-show="errorMsg.length > 0">
 			<span class="fa fa-warning" aria-hidden="true"></span>

--- a/src/client/templates/settings.html
+++ b/src/client/templates/settings.html
@@ -12,30 +12,36 @@
     </div>
 
     <div class="col-xs-12 col-sm-3 col-lg-2">
-        <div ng-if="!loading && gist.id.length > 0" class="text">
-            <a ng-href="{{gist.html_url}}" target="space">{{getGistName()}}</a>
+        <div>
+            <a ng-if="!loading && gist.id.length > 0" ng-href="{{gist.html_url}}" target="space">{{getGistName()}}</a>
+            <span ng-if="!item.gist">Disabled</span>
         </div>
     </div>
 
     <div class="col-xs-12 col-lg-2 hidden-xs hidden-sm hidden-md text">
-        <a ng-href="{{gist.html_url}}" target="space">{{gist.html_url}}</a>
+        <a ng-if="item.gist" ng-href="{{gist.html_url}}" target="space">{{gist.html_url}}</a>
     </div>
 
     <div class="col-xs-12 col-sm-2 col-lg-2 text">
-        {{gist.updated_at | date:'longDate'}}
+        <span ng-if="item.gist">{{gist.updated_at | date:'longDate'}}</span>
     </div>
 
     <div class="col-xs-12 col-sm-1 col-lg-1 text">
-        {{ item.sharedGist ? 'Yes' : 'No' }}
+        <span ng-if="item.gist">{{ item.sharedGist ? 'Yes' : 'No' }}</span>
     </div>
 
-    <div class="col-xs-4 col-sm-1 col-lg-1" style="text-align:center; text-decoration: underline;">
-        <a ng-click="getReport(item);" class="clickable">{{signatures.value.length}}</a>
+    <div class="col-xs-4 col-sm-1 col-lg-1" style="text-align:center">
+        <a ng-if="item.gist" ng-click="getReport(item);" class="clickable" style="text-decoration: underline;">{{signatures.value.length}}</a>
     </div>
 
     <script type="text/ng-template" id="validateLink.html">
-        <i class="fa" ng-class="valid.gist ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> gist</i>
-        <i class="fa" ng-class="valid.webhook ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> webhook</i>
+        <div ng-if="item.gist">
+            <i class="fa" ng-class="valid.gist ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> gist</i>
+            <i class="fa" ng-class="valid.webhook ? 'fa-check' : 'fa-times'" style="white-space: nowrap;"> webhook</i>
+        </div>
+        <div ng-if="!item.gist">
+            <i class="fa fa-check" style="white-space: nowrap;"> disabled</i>
+        </div>
     </script>
     <div class="col-xs-4 col-sm-1 col-lg-1 center-block">
         <img ng-src="/assets/images/{{isLinkActive() ? 'link_active.svg' : 'link_inactive.svg'}}" popover-placement="right" popover-template="'validateLink.html'"
@@ -43,9 +49,9 @@
     </div>
 
     <script type="text/ng-template" id="moreActions.html">
-        <button class="btn btn-info" ng-click="upload(item)">Import</button>
+        <button class="btn btn-info" ng-click="upload(item)" ng-if='item.gist'>Import</button>
         <button class="btn btn-info" ng-click="recheck(item)">Recheck PRs</button>
-        <button class="btn btn-info" ng-click="getBadge(item)" ng-show="item.repo">Get Badge</button>
+        <button class="btn btn-info" ng-click="getBadge(item)" ng-show="item.repo && item.gist">Get Badge</button>
     </script>
     <div class="col-xs-4 col-sm-1 action" ng-init="popoverIsOpen=false" ng-show="(item.org && user.value.org_admin) || item.repo">
         <i class="fa fa-ellipsis-h action-icon" tooltip-placement="bottom" tooltip="More..." popover-placement="right" popover-template="'moreActions.html'"

--- a/src/config.js
+++ b/src/config.js
@@ -86,7 +86,17 @@ module.exports = {
         api_access: {
             free: ['/api/cla/get', '/api/cla/getLinkedItem'],
             external: ['/api/cla/getAll'],
-            admin_only: ['/api/cla/addSignature', '/api/cla/hasSignature', '/api/cla/terminateSignature', '/api/cla/validate', '/api/cla/getGist']
+            admin_only: [
+                '/api/cla/addSignature',
+                '/api/cla/hasSignature',
+                '/api/cla/terminateSignature',
+                '/api/cla/validate',
+                '/api/cla/getGist',
+                '/api/org/create',
+                '/api/org/remove',
+                '/api/repo/create',
+                '/api/repo/remove'
+            ]
         },
 
         static: [

--- a/src/config.js
+++ b/src/config.js
@@ -85,7 +85,8 @@ module.exports = {
 
         api_access: {
             free: ['/api/cla/get', '/api/cla/getLinkedItem'],
-            external: ['/api/cla/getAll']
+            external: ['/api/cla/getAll'],
+            admin_only: ['/api/cla/addSignature', '/api/cla/hasSignature', '/api/cla/terminateSignature', '/api/cla/validate', '/api/cla/getGist']
         },
 
         static: [

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -535,6 +535,7 @@ let ClaApi = {
         let args = {
             repo: req.args.repo,
             owner: req.args.owner,
+            number: req.args.number,
             user: req.user.login
         };
 

--- a/src/server/api/repo.js
+++ b/src/server/api/repo.js
@@ -1,31 +1,59 @@
 // module
-var repo = require('../services/repo');
-var log = require('../services/logger');
+let  repo = require('../services/repo');
+let  log = require('../services/logger');
+let  Joi = require('joi');
+let  webhook = require('./webhook');
 
 module.exports = {
 
     check: function(req, done) {
         repo.check(req.args, done);
     },
-    create: function(req, done){
-        req.args.token = req.user.token;
-        var repoArgs = {
-            repo: req.args.repo,
-            owner: req.args.owner,
-            token: req.args.token
-        };
-        repo.get(repoArgs, function (error, dbRepo) {
-            if (dbRepo) {
-                repo.getGHRepo(repoArgs, function (err, ghRepo) {
-                    if (err || (ghRepo && ghRepo.id != dbRepo.repoId)) {
-                        repo.update(req.args, done);
-                    } else {
-                        done('This repository is already linked.');
-                    }
-                });
-            } else {
-                repo.create(req.args, done);
+    create: function (req, done) {
+        req.args.token = req.args.token || req.user.token;
+        let  schema = Joi.object().keys({
+            owner: Joi.string().required(),
+            repo: Joi.string().required(),
+            repoId: Joi.number().required(),
+            token: Joi.string().required(),
+            gist: Joi.alternatives().try(Joi.string().uri(), Joi.any().allow([null])), // Null CLA
+            sharedGist: Joi.boolean(),
+            minFileChanges: Joi.number(),
+            minCodeChanges: Joi.number()
+        });
+        Joi.validate(req.args, schema, { abortEarly: false, allowUnknown: true }, function (joiError) {
+            if (joiError) {
+                joiError.code = 400;
+                return done(joiError);
             }
+            let  repoArgs = {
+                repo: req.args.repo,
+                owner: req.args.owner,
+                token: req.args.token
+            };
+            repo.get(repoArgs, function (error, dbRepo) {
+                if (dbRepo) {
+                    repo.getGHRepo(repoArgs, function (err, ghRepo) {
+                        if (err || (ghRepo && ghRepo.id != dbRepo.repoId)) {
+                            repo.update(req.args, done);
+                        } else {
+                            done('This repository is already linked.');
+                        }
+                    });
+                } else {
+                    repo.create(req.args, function (createRepoErr, dbRepo) {
+                        if (createRepoErr) {
+                            return done(createRepoErr);
+                        }
+                        if (!dbRepo.gist) {
+                            return done(null, dbRepo);
+                        }
+                        webhook.create(req, function (createHookErr) {
+                            done(createHookErr, dbRepo);
+                        });
+                    });
+                }
+            });
         });
     },
     // get: function(req, done){
@@ -49,7 +77,31 @@ module.exports = {
     update: function(req, done){
         repo.update(req.args, done);
     },
-    remove: function(req, done){
-        repo.remove(req.args, done);
+    remove: function (req, done) {
+        let  schema = Joi.alternatives().try(Joi.object().keys({
+            owner: Joi.string().required(),
+            repo: Joi.string().required(),
+        }), Joi.object().keys({
+            repoId: Joi.number().required()
+        }));
+        Joi.validate(req.args, schema, { abortEarly: false }, function (joiError) {
+            if (joiError) {
+                joiError.code = 400;
+                return done(joiError);
+            }
+            repo.remove(req.args, function (removeRepoErr, dbRepo) {
+                if (removeRepoErr) {
+                    return done(removeRepoErr);
+                }
+                if (!dbRepo || !dbRepo.gist) {
+                    return done(null, dbRepo);
+                }
+                req.args.owner = dbRepo.owner;
+                req.args.repo = dbRepo.repo;
+                webhook.remove(req, function (removeHookErr) {
+                    done(removeHookErr, dbRepo);
+                });
+            });
+        });
     }
 };

--- a/src/server/api/webhook.js
+++ b/src/server/api/webhook.js
@@ -1,53 +1,34 @@
 // module
-var github = require('../services/github');
-var repoService = require('../services/repo');
-var url = require('../services/url');
+let github = require('../services/github');
+let repoService = require('../services/repo');
+let url = require('../services/url');
+let async = require('async');
 
-function createRepoHook(req, done) {
-    github.call({
-        obj: 'repos',
-        fun: 'createHook',
-        arg: {
-            owner: req.args.owner,
-            repo: req.args.repo,
-            name: 'web',
-            config: { url: url.webhook(req.args.repo), content_type: 'json' },
-            events: ['pull_request'],
-            active: true
-        },
-        noCache: true,
-        token: req.user.token
-    }, done);
-}
-
-function updateRepoHook(owner, repo, id, active, token, done) {
-    github.call({
-        obj: 'repos',
-        fun: 'editHook',
-        arg: {
-            owner: owner,
-            repo: repo,
-            name: 'web',
-            config: { url: url.webhook(repo), content_type: 'json' },
-            id: id,
-            active: active
-        },
-        noCache: true,
-        token: token
-    }, done);
-}
-
-function getHook(obj, arg, token, done) {
-    github.call({
-        obj: obj,
+function getHook(owner, repo, noCache, token, done) {
+    if (!owner || !token) {
+        return done('Owner/org and token is required.');
+    }
+    let args = {
         fun: 'getHooks',
-        arg: arg,
+        arg: {
+            noCache: noCache
+        },
         token: token
-    }, function callback(err, hooks) {
+    };
+    if (repo) {
+        args.obj = 'repos';
+        args.arg.owner = owner;
+        args.arg.repo = repo;
+    } else {
+        args.obj = 'orgs';
+        args.arg.org = owner;
+    }
+    github.call(args, function callback(err, hooks) {
         let hook = null;
+
         if (!err && hooks && hooks.length > 0) {
-            hooks.forEach(function (webhook) {
-                if (webhook.config.url && webhook.config.url.indexOf(url.baseWebhook) > -1) {
+            hooks.forEach(function(webhook) {
+                if (webhook.active && webhook.config.url && webhook.config.url.indexOf(url.baseWebhook) > -1) {
                     hook = webhook;
                 }
             });
@@ -59,61 +40,152 @@ function getHook(obj, arg, token, done) {
     });
 }
 
-function deactevateRepoHook(owner, repo, token, done) {
-    getHook('repos', {
-        owner: owner,
-        repo: repo
-    }, token, function (err, hook) {
-        if (hook && hook.id) {
-            updateRepoHook(owner, repo, hook.id, false, token, done);
+function getRepoHook(owner, repo, noCache, token, done) {
+    getHook(owner, repo, noCache, token, function (error, hook) {
+        if (error || hook) {
+            return done(error, hook);
         }
-    });
-}
-
-function createOrgHook(req, done) {
-    var org = req.args.org;
-    var args = {
-        obj: 'orgs',
-        fun: 'createHook',
-        arg: {
-            org: org,
-            name: 'web',
-            config: { url: url.webhook(org), content_type: 'json' },
-            events: ['pull_request'],
-            noCache: true,
-            active: true
-        },
-        token: req.user.token
-    };
-    github.call(args, function (err, data) {
-        done(err, data);
-        repoService.getByOwner(org, function (err, repos) {
-            if (repos && repos.length > 0) {
-                repos.forEach(function (repo) {
-                    deactevateRepoHook(org, repo.repo, repo.token, function () { });
-                });
+        getHook(owner, undefined, noCache, token, function (error, hook) {
+            if (error && error.code !== 404) {
+                // When the owner is not an org, github returns 404.
+                return done(error);
             }
+            return done(null, hook);
         });
     });
 }
 
-function extractGithubArgs(args) {
-    var obj = args.org ? 'orgs' : 'repos';
-    var arg = args.org ? {
-        org: args.org
-    } : {
-            owner: args.owner,
-            repo: args.repo
-        };
-    return { obj: obj, arg: arg };
+function getOrgHook(org, noCache, token, done) {
+    getHook(org, undefined, noCache, token, done);
+}
+
+function createHook(owner, repo, token, done) {
+    if (!owner || !token) {
+        return done('Owner/org and token is required.');
+    }
+    let args = {
+        fun: 'createHook',
+        arg: {
+            noCache: true,
+            config: { content_type: 'json' },
+            name: 'web',
+            events: ['pull_request'],
+            active: true
+        },
+        token: token
+    };
+    if (repo) {
+        args.obj = 'repos';
+        args.arg.repo = repo;
+        args.arg.owner = owner;
+        args.arg.config.url = url.webhook(repo);
+    } else {
+        args.obj = 'orgs';
+        args.arg.org = owner;
+        args.arg.config.url = url.webhook(owner);
+    }
+    github.call(args, done);
+}
+
+function createRepoHook(owner, repo, token, done) {
+    getRepoHook(owner, repo, true, token, function (error, hook) {
+        if (error || hook) {
+            return done(error, hook);
+        }
+        createHook(owner, repo, token, done);
+    });
+}
+
+function createOrgHook(org, token, done) {
+    getOrgHook(org, true, token, function (error, hook) {
+        if (error || hook) {
+            return done(error || 'Webhook already exist with base url ' + url.baseWebhook);
+        }
+        createHook(org, undefined, token, function (err, hook) {
+            if (err) {
+                return done(err, null);
+            }
+            handleHookForLinkedRepoInOrg(org, token, removeRepoHook, function (e) {
+                done(e, hook);
+            });
+        });
+    });
+}
+
+function removeHook(owner, repo, hookId, token, done) {
+    if (!owner || !token) {
+        return done('Owner/org and token is required.');
+    }
+    let args = {
+        fun: 'deleteHook',
+        arg: {
+            id: hookId,
+            noCache: true
+        },
+        token: token
+    };
+    if (repo) {
+        args.obj = 'repos';
+        args.arg.owner = owner;
+        args.arg.repo = repo;
+    } else {
+        args.obj = 'orgs';
+        args.arg.org = owner;
+    }
+    github.call(args, done);
+}
+
+function removeRepoHook(owner, repo, token, done) {
+    getRepoHook(owner, repo, true, token, function (err, hook) {
+        if (err || !hook) {
+            return done(err || 'No webhook found with base url ' + url.baseWebhook);
+        }
+        if (hook.type === 'Organization') {
+            return done(null, null);
+        }
+        removeHook(owner, repo, hook.id, token, done);
+    });
+}
+
+function removeOrgHook(org, token, done) {
+    getOrgHook(org, true, token, function (error, hook) {
+        if (error || !hook) {
+            return done(error || 'No webhook found with base url ' + url.baseWebhook);
+        }
+        removeHook(org, undefined, hook.id, token, function (err, result) {
+            if (err) {
+                return done(err, null);
+            }
+            handleHookForLinkedRepoInOrg(org, token, createRepoHook, function (e) {
+                done(e, hook);
+            });
+        });
+    });
+}
+
+function handleHookForLinkedRepoInOrg(org, token, delegateFun, done) {
+    repoService.getByOwner(org, function (error, repos) {
+        if (error || !repos || repos.length === 0) {
+            return done(error);
+        }
+        async.series(repos.map(function (repo) {
+            return function (callback) {
+                if (!repo.gist) {
+                    // Repos with Null CLA will NOT have webhook
+                    return callback(null, null);
+                }
+                delegateFun(repo.owner, repo.repo, token, callback);
+            };
+        }), function (err, results) {
+            done(err);
+        });
+    });
 }
 
 module.exports = {
 
     get: function (req, done) {
-        var githubArgs = extractGithubArgs(req.args);
-
-        getHook(githubArgs.obj, githubArgs.arg, req.user.token, done);
+        return req.args && req.args.org ? getOrgHook(req.args.org, req.args.noCache, req.user.token, done) : getRepoHook(req.args.owner, req.args.repo, req.args.noCache, req.user.token, done);
 
         // now we will have to check two things:
         // 1) webhook user still has push access to this repo
@@ -125,27 +197,11 @@ module.exports = {
         // }
     },
 
-    create: function (req, done) {
-        return req.args && req.args.orgId ? createOrgHook(req, done) : createRepoHook(req, done);
+    create: function(req, done) {
+        return req.args && req.args.orgId ? createOrgHook(req.args.org, req.user.token, done) : createRepoHook(req.args.owner, req.args.repo, req.user.token, done);
     },
 
     remove: function (req, done) {
-        this.get(req, function (err, hook) {
-            if (err || !hook) {
-                done(err || 'No webhook found with base url ' + url.baseWebhook);
-                return;
-            }
-            var githubArgs = extractGithubArgs(req.args);
-            githubArgs.arg.id = hook.id;
-            githubArgs.arg.noCache = true;
-
-            github.call({
-                obj: githubArgs.obj,
-                fun: 'deleteHook',
-                arg: githubArgs.arg,
-                token: req.user.token
-            }, done);
-        });
-
+        return req.args && req.args.org ? removeOrgHook(req.args.org, req.user.token, done) : removeRepoHook(req.args.owner, req.args.repo, req.user.token, done);
     }
 };

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -202,9 +202,9 @@ app.all('/api/:obj/:fun', function (req, res) {
         if (err && typeof err === 'string') {
             return res.status(500).send(err);
         } else if (err) {
-            return res.status(err.code > 0 ? err.code : 500).send(JSON.stringify(err.text || err));
+            return res.status(err.code > 0 ? err.code : 500).send(JSON.stringify(err.text || err.message || err));
         }
-        if (obj) {
+        if (obj !== undefined && obj !== null) {
             obj = cleanup.cleanObject(obj);
             res.send(JSON.stringify(obj));
         } else {

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -37,7 +37,7 @@ app.use(function (req, res, next) {
 });
 
 app.use(require('x-frame-options')());
-app.use(require('body-parser').json());
+app.use(require('body-parser').json({ limit: '5mb' }));
 app.use(require('cookie-parser')());
 var expressSession = require('express-session');
 var MongoStore = require('connect-mongo')(expressSession);

--- a/src/server/controller/user.js
+++ b/src/server/controller/user.js
@@ -1,5 +1,6 @@
 var passport = require('passport');
 var express = require('express');
+var utils = require('../middleware/utils');
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 // User controller
@@ -41,10 +42,7 @@ router.get('/auth/github/callback', passport.authenticate('github', {
         failureRedirect: '/'
     }),
     function (req, res) {
-        function couldBeAdmin(username) {
-            return config.server.github.admin_users.length === 0 || config.server.github.admin_users.indexOf(username) >= 0;
-        }
-        if (req.user && req.session.requiredScope != 'public' && couldBeAdmin(req.user.login) && (!req.user.scope || req.user.scope.indexOf('write:repo_hook') < 0)) {
+        if (req.user && req.session.requiredScope != 'public' && utils.couldBeAdmin(req.user.login) && (!req.user.scope || req.user.scope.indexOf('write:repo_hook') < 0)) {
             return res.redirect('/auth/github?admin=true');
         }
         res.redirect(req.session.returnTo || req.headers.referer || '/');

--- a/src/server/documents/cla.js
+++ b/src/server/documents/cla.js
@@ -4,6 +4,7 @@ mongoose.Promise = require('q').Promise;
 
 var CLASchema = mongoose.Schema({
     created_at: Date,
+    end_at: Date,
     custom_fields: String,
     gist_url: String,
     gist_version: String,

--- a/src/server/documents/org.js
+++ b/src/server/documents/org.js
@@ -7,7 +7,9 @@ var OrgSchema = mongoose.Schema({
     gist: String,
     token: String,
     excludePattern: String,
-    sharedGist: Boolean
+    sharedGist: Boolean,
+    minFileChanges: Number,
+    minCodeChanges: Number
 });
 
 OrgSchema.methods.isRepoExcluded = function(repo) {

--- a/src/server/documents/repo.js
+++ b/src/server/documents/repo.js
@@ -7,7 +7,9 @@ var RepoSchema = mongoose.Schema({
     owner: String,
     gist: String,
     token: String,
-    sharedGist: Boolean
+    sharedGist: Boolean,
+    minFileChanges: Number,
+    minCodeChanges: Number
 });
 
 var index = {

--- a/src/server/middleware/utils.js
+++ b/src/server/middleware/utils.js
@@ -1,0 +1,83 @@
+let githubService = require('../services/github');
+let log = require('../services/logger');
+let q = require('q');
+
+module.exports = {
+    couldBeAdmin: function (username) {
+        return config.server.github.admin_users.length === 0 || config.server.github.admin_users.indexOf(username) >= 0;
+    },
+
+    checkRepoPushPermissionByName: function (repo, owner, token) {
+        let deferred = q.defer();
+        githubService.call({
+            obj: 'repos',
+            fun: 'get',
+            arg: {
+                repo: repo,
+                owner: owner
+            },
+            token: token
+        }, function (err, data) {
+            if (!err && !data) {
+                err = new Error('No data returned');
+            }
+            if (err && err.code === 404) {
+                log.info('You do not have authorization for ' + repo + ' repository.');
+            }
+            if (err) {
+                return deferred.reject(err);
+            }
+            if (!data.permissions['push']) {
+                return deferred.reject('You do not have push permission for this repo');
+            }
+            deferred.resolve(data);
+        });
+        return deferred.promise;
+    },
+
+    checkRepoPushPermissionById: function (repoId, token, cb) {
+        githubService.call({
+            obj: 'repos',
+            fun: 'getById',
+            arg: {
+                id: repoId
+            },
+            token: token
+        }, function (err, data) {
+            if (err || !data) {
+                cb(err, data);
+                return;
+            }
+            let hasPermission = data.permissions['push'];
+            cb(err, hasPermission);
+        });
+    },
+
+    checkOrgAdminPermission: function (org, username, token) {
+        let deferred = q.defer();
+        githubService.call({
+            obj: 'orgs',
+            fun: 'getOrgMembership',
+            arg: {
+                org: org,
+                username: username
+            },
+            token: token
+        }, function (err, data) {
+            if (!err && !data) {
+                err = new Error('No data returned');
+            }
+            if (err && err.code === 404) {
+                log.info('You do not have authorization for ' + org + ' organization.');
+            }
+            if (err) {
+                return deferred.reject(err);
+            }
+            if (data.role !== 'admin') {
+                return deferred.reject('You are not an admin of this org');
+            }
+            return deferred.resolve(data);
+        });
+        return deferred.promise;
+    },
+};

--- a/src/server/passports/token.js
+++ b/src/server/passports/token.js
@@ -59,7 +59,7 @@ passport.use(new Strategy(
                         done(err || 'Could not find ' + data.login);
                         return;
                     }
-                    done(err, merge(data._json, {
+                    done(err, merge(data, {
                         token: dbUser.token,
                         scope: authorization.scopes.toString()
                     }));

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -419,14 +419,18 @@ module.exports = function () {
             let self = this;
             return getLinkedItem(args.repo, args.owner, args.token).then(function (item) {
                 if (!item.gist) {
-                    throw new Error('The repository don\'t need to sign a CLA because it has a null CLA.');
+                    let nullClaErr = new Error('The repository don\'t need to sign a CLA because it has a null CLA.');
+                    nullClaErr.code = 200;
+                    throw nullClaErr;
                 }
                 return getGistObject(item.gist, item.token).then(function (gist) {
                     let onDates = [new Date()];
                     let currentVersion = gist.data.history[0].version;
                     return getLastSignatureOnMultiDates(args.user, args.userId, item.repoId, item.orgId, item.sharedGist, item.gist, currentVersion, onDates).then(function (cla) {
                         if (cla) {
-                            throw new Error('You\'ve already signed the cla');
+                            let signedErr = new Error('You\'ve already signed the cla');
+                            signedErr.code = 200;
+                            throw signedErr;
                         }
                         let argsToCreate = {
                             user: args.user,
@@ -601,7 +605,9 @@ module.exports = function () {
         terminate: function (args, done) {
             return getLinkedItem(args.repo, args.owner, args.token).then(function (item) {
                 if (!item.gist) {
-                    throw new Error('The repository don\'t need to sign a CLA because it has a null CLA.');
+                    let nullClaErr = new Error('The repository don\'t need to sign a CLA because it has a null CLA.');
+                    nullClaErr.code = 200;
+                    throw nullClaErr;
                 }
                 return getGistObject(item.gist, item.token).then(function (gist) {
                     let endDate = new Date(args.endDate);
@@ -609,7 +615,9 @@ module.exports = function () {
                     let currentVersion = gist.data.history[0].version;
                     return getLastSignatureOnMultiDates(args.user, args.userId, item.repoId, item.orgId, item.sharedGist, item.gist, currentVersion, onDates).then(function (cla) {
                         if (!cla) {
-                            throw new Error('No valid cla record');
+                            let noRecordErr = new Error('No valid cla record');
+                            noRecordErr.code = 200;
+                            throw noRecordErr;
                         }
                         cla.end_at = endDate;
                         return cla.save().then(function (dbCla) {

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -76,7 +76,7 @@ let githubService = {
         let github = newGithubApi();
 
         function collectData(err, res) {
-            data = res && res.data ? concatData(data, res).data : data;
+            data = res && res.data ? concatData(data, res.data) : data;
 
             let meta = {};
             try {

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -4,6 +4,7 @@ let request = require('request');
 let cache = require('memory-cache');
 let config = require('../../config');
 let GitHubApi = require('github');
+let stringify = require('json-stable-stringify');
 
 
 // let githubApi;
@@ -67,10 +68,13 @@ let githubService = {
         let obj = call.obj;
         let token = call.token;
 
-        let stringArgs = JSON.stringify({
+        let argWithoutNoCache = Object.assign({}, arg);
+        delete argWithoutNoCache.noCache;
+
+        let stringArgs = stringify({
             obj: call.obj,
             fun: call.fun,
-            arg: call.arg,
+            arg: argWithoutNoCache,
             token: call.token
         });
         let github = newGithubApi();

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -15,7 +15,9 @@ module.exports = {
             gist: args.gist,
             token: args.token,
             excludePattern: args.excludePattern,
-            sharedGist: !!args.sharedGist
+            sharedGist: !!args.sharedGist,
+            minFileChanges: args.minFileChanges,
+            minCodeChanges: args.minCodeChanges
         }, function (err, org) {
             done(err, org);
         });

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -22,7 +22,12 @@ module.exports = {
     },
 
     get: function (args, done) {
-        Org.findOne(selection(args), done);
+        Org.findOne(selection(args), function (err, org) {
+            if (!err && !org) {
+                err = 'Organization not found in Database';
+            }
+            done(err, org);
+        });
     },
 
     getMultiple: function (args, done) {

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -41,6 +41,6 @@ module.exports = {
     },
 
     remove: function (args, done) {
-        Org.remove(selection(args), done);
+        Org.findOneAndRemove(selection(args), done);
     }
 };

--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -158,5 +158,40 @@ module.exports = {
         if (typeof done === 'function') {
             done();
         }
+    },
+
+    deleteComment: function (args, done) {
+        this.getComment({
+            repo: args.repo,
+            owner: args.owner,
+            number: args.number
+        }, function (error, comment) {
+            if (error) {
+                return log.warn(error, 'with args:', args.repo, args.owner, args.number);
+            }
+            if (!comment) {
+                return;
+            }
+            github.call({
+                obj: 'issues',
+                fun: 'deleteComment',
+                arg: {
+                    owner: args.owner,
+                    repo: args.repo,
+                    id: comment.id
+                },
+                basicAuth: {
+                    user: config.server.github.user,
+                    pass: config.server.github.pass
+                }
+            }, function (error) {
+                if (error) {
+                    log.warn(error, 'with args:', args, 'and commentId: ', comment.id);
+                }
+            });
+        });
+        if (typeof done === 'function') {
+            done();
+        }
     }
 };

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -180,7 +180,7 @@ module.exports = {
                             let committer = extractUserFromCommit(edge.node.commit);
                             let user = {
                                 name: committer.login || committer.name,
-                                id: committer.id || ''
+                                id: committer.databaseId || ''
                             };
                             if (committers.length === 0 || committers.map(function (c) {
                                 return c.name;

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -125,7 +125,7 @@ module.exports = {
         });
     },
     remove: function (args, done) {
-        Repo.remove(selection(args)).exec(done);
+        Repo.findOneAndRemove(selection(args), done);
     },
 
     getPRCommitters: function (args, done) {

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -72,7 +72,9 @@ module.exports = {
             repoId: args.repoId,
             gist: args.gist,
             token: args.token,
-            sharedGist: !!args.sharedGist
+            sharedGist: !!args.sharedGist,
+            minFileChanges: args.minFileChanges,
+            minCodeChanges: args.minCodeChanges
         }, function (err, repo) {
             done(err, repo);
         });

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -234,19 +234,18 @@ module.exports = {
 
         };
 
-        orgService.get({
-            orgId: args.orgId
-        }, function (e, org) {
-            if (!org) {
-                self.get(args, function (e, repo) {
-                    if (e || !repo) {
-                        handleError(new Error(e).stack, e, args);
-                        return;
+        self.get(args, function (error, repo) {
+            if (!repo) {
+                orgService.get({
+                    orgId: args.orgId
+                }, function (err, org) {
+                    if (!org) {
+                        return handleError(new Error(error).stack, error, args);
                     }
-                    collectTokenAndCallGithub(args, repo);
+                    collectTokenAndCallGithub(args, org);
                 });
             } else {
-                collectTokenAndCallGithub(args, org);
+                collectTokenAndCallGithub(args, repo);
             }
         });
     },

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -1,6 +1,8 @@
 require('../documents/repo');
 let mongoose = require('mongoose');
 let Repo = mongoose.model('Repo');
+let _ = require('lodash');
+let async = require('async');
 
 //services
 let github = require('../services/github');
@@ -94,9 +96,20 @@ module.exports = {
                 repoId: repo.repoId
             });
         });
-        Repo.find({
-            $or: repoIds
-        }, done);
+        var idChunk = _.chunk(repoIds, 100);
+        async.parallelLimit(idChunk.map(function (chunk) {
+            return function (callback) {
+                Repo.find({
+                    $or: chunk
+                }, callback);
+            };
+        }), 3, function (err, repoChunk) {
+            if (err) {
+                return done(err);
+            }
+            repos = _.concat.apply(null, repoChunk);
+            done(null, repos);
+        });
     },
 
     getByOwner: function (owner, done) {

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -36,8 +36,12 @@ function storeRequest(committers, repo, owner, number) {
             let repoPullRequests = user.requests.find((request) => {
                 return request.repo === repo && request.owner === owner;
             });
-            if (repoPullRequests.numbers.indexOf(number) < 0) {
+            if (repoPullRequests && repoPullRequests.numbers.indexOf(number) < 0) {
                 repoPullRequests.numbers.push(number);
+                user.save();
+            }
+            if (!repoPullRequests) {
+                user.requests.push(pullRequest);
                 user.save();
             }
         });

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -95,26 +95,29 @@ module.exports = function (req, res) {
 
 
         setTimeout(function () {
-            orgService.get({
-                orgId: args.orgId
-            }, function (err, org) {
-                if (org) {
-                    args.token = org.token;
-                    args.gist = org.gist; //TODO: Test it!!
-                    if (!org.isRepoExcluded(args.repo)) {
-                        repoService.getGHRepo(args, function (err, repo) {
-                            if (repo) {
-                                handleWebHook(args);
-                            }
-                        });
+            repoService.get(args, function (e, repo) {
+                if (repo) {
+                    if (!repo.gist) {
+                        return;
                     }
-                } else {
                     args.orgId = undefined;
-                    repoService.get(args, function (e, repo) {
-                        if (repo) {
-                            args.token = repo.token;
-                            args.gist = repo.gist; //TODO: Test it!!
-                            handleWebHook(args);
+                    args.token = repo.token;
+                    args.gist = repo.gist; //TODO: Test it!!
+                    handleWebHook(args);
+                } else {
+                    orgService.get({
+                        orgId: args.orgId
+                    }, function (err, org) {
+                        if (org) {
+                            args.token = org.token;
+                            args.gist = org.gist; //TODO: Test it!!
+                            if (!org.isRepoExcluded(args.repo)) {
+                                repoService.getGHRepo(args, function (err, repo) {
+                                    if (repo) {
+                                        handleWebHook(args);
+                                    }
+                                });
+                            }
                         }
                     });
                 }

--- a/src/tests/client/controller/ClaCtrl.spec.js
+++ b/src/tests/client/controller/ClaCtrl.spec.js
@@ -67,7 +67,7 @@ describe('CLA Controller', function() {
         httpBackend.when('GET', '/config').respond({ });
 
         scope = $rootScope.$new();
-        stateParams = {user: 'login', repo: 'myRepo'};
+        stateParams = {user: 'login', repo: 'myRepo', pullRequest: '1'};
 
         user.value = {id: 123, login: 'login'};
         user.meta = {scopes: 'user:email, repo, repo:status, read:repo_hook, write:repo_hook, read:org'};
@@ -80,7 +80,7 @@ describe('CLA Controller', function() {
         createCtrl = function() {
             // httpBackend.when('POS  T', '/api/github/call', { obj: 'user', fun: 'get', arg: {} }).respond(user);
             httpBackend.when('POST', '/api/cla/getLinkedItem', {repo: stateParams.repo, owner: stateParams.user}).respond(linkedItem);
-            httpBackend.when('POST', '/api/cla/check', {repo: stateParams.repo, owner: stateParams.user}).respond(claSigned);
+            httpBackend.when('POST', '/api/cla/check', {repo: stateParams.repo, owner: stateParams.user, number: stateParams.pullRequest}).respond(claSigned);
             httpBackend.when('POST', '/api/cla/get', {repoId: linkedItem.repoId}).respond(claText);
 
             var ctrl = $controller('ClaController', {
@@ -327,7 +327,7 @@ describe('CLA Controller', function() {
         httpBackend.flush();
         _timeout.flush();
 
-        (_window.location.href).should.be.equal('https://github.com/login/myRepo');
+        (_window.location.href).should.be.equal('https://github.com/login/myRepo/pull/1');
         (claController.scope.signed).should.be.ok;
     });
 
@@ -388,7 +388,7 @@ describe('CLA Controller', function() {
         httpBackend.flush();
 
         claController.scope.agree();
-        (_window.location.href).should.be.equal('/accept/login/myRepo');
+        (_window.location.href).should.be.equal('/accept/login/myRepo?pullRequest=1');
     });
 
     it('should call cla:sign on agree if there are customFields and user is logged in', function(){

--- a/src/tests/client/controller/HomeCtrl.spec.js
+++ b/src/tests/client/controller/HomeCtrl.spec.js
@@ -266,16 +266,6 @@ describe('Home Controller', function () {
                 response = expRes.RPC.org && expRes.RPC.org.remove ? expRes.RPC.org.remove : {
                     value: true
                 };
-            } else if (o === 'webhook' && f === 'create') {
-                response = expRes.RPC.webhook && expRes.RPC.webhook.create ? expRes.RPC.webhook.create : {
-                    value: {
-                        active: true
-                    }
-                };
-            } else if (o === 'webhook' && f === 'remove') {
-                response = expRes.RPC.webhook && expRes.RPC.webhook.remove ? expRes.RPC.webhook.remove : {
-                    value: true
-                };
             } else {
                 return rpcCall(o, f, args, cb);
             }
@@ -556,7 +546,7 @@ describe('Home Controller', function () {
         (homeCtrl.scope.repos.length).should.be.equal(0);
     });
 
-    it('should create repo entry and webhook on link action', function () {
+    it('should create repo entry on link action', function () {
         homeCtrl = createCtrl();
         httpBackend.flush();
 
@@ -585,7 +575,6 @@ describe('Home Controller', function () {
         (homeCtrl.scope.claRepos[1].repo).should.be.equal('myRepo');
         (homeCtrl.scope.claRepos[1].active).should.be.ok;
         (homeCtrl.scope.claRepos[1].fork).should.be.ok;
-        calledApi.RPC.webhook.create.should.be.ok;
     });
 
     it('should link organisation', function () {
@@ -604,48 +593,9 @@ describe('Home Controller', function () {
         (homeCtrl.scope.claOrgs[0].avatarUrl).should.be.equal(testDataOrgs[0].avatarUrl);
         // (homeCtrl.scope.claRepos[1].active).should.be.ok;
         // (homeCtrl.scope.claRepos[1].fork).should.be.ok;
-        calledApi.RPC.webhook.create.should.be.ok;
     });
 
-    it('should set active flag depending on webhook response', function () {
-        homeCtrl = createCtrl();
-        httpBackend.flush();
-
-        homeCtrl.scope.repos = [{
-            name: 'myRepo',
-            owner: {
-                login: 'login'
-            },
-            fork: true
-        }];
-
-        homeCtrl.scope.selected.item = {
-            id: 123,
-            name: 'myRepo',
-            full_name: 'login/myRepo',
-            owner: {
-                login: 'login'
-            }
-        };
-        homeCtrl.scope.selected.gist = {
-            url: 'https://gist.github.com/gistId'
-        };
-
-        expRes.RPC.webhook = {
-            create: {
-                value: {
-                    active: false
-                }
-            }
-        };
-
-        homeCtrl.scope.link();
-
-        (homeCtrl.scope.claRepos[1].repo).should.be.equal('myRepo');
-        (homeCtrl.scope.claRepos[1].active).should.be.not.ok;
-    });
-
-    it('should remove repo from claRepos list and remove webhook from github if create failed on backend', function () {
+    it('should remove repo from claRepos list from github if create failed on backend', function () {
         homeCtrl = createCtrl();
         httpBackend.flush();
 
@@ -675,36 +625,7 @@ describe('Home Controller', function () {
 
         homeCtrl.scope.link();
 
-        ($RPCService.call.calledWithMatch('webhook', 'remove')).should.be.equal(true);
         (homeCtrl.scope.claRepos.length).should.be.equal(1);
-    });
-
-    it('should show error message if create failed but not remove webhook if repo already linked', function () {
-        homeCtrl = createCtrl();
-        httpBackend.flush();
-
-        homeCtrl.scope.selected.gist = {
-            url: 'https://gist.github.com/gistId'
-        };
-        homeCtrl.scope.selected.item = {
-            id: 123,
-            name: 'myRepo',
-            full_name: 'login/myRepo',
-            owner: {
-                login: 'login'
-            }
-        };
-
-        rpcRepoCreate = {
-            error: {
-                errmsg: 'nsertDocument :: caused by :: 11000 E11000 duplicate key error index: cla-staging.repos.$repo_1_owner_1  dup key: { : "myRepo", : "login" }'
-            }
-        };
-
-        homeCtrl.scope.link();
-
-        ($RPCService.call.calledWithMatch('webhook', 'remove')).should.be.equal(false);
-        (homeCtrl.scope.errorMsg[0]).should.be.equal('This repository is already set up.');
     });
 
     it('should cleanup if create failed', function () {
@@ -731,14 +652,10 @@ describe('Home Controller', function () {
 
         homeCtrl.scope.link();
 
-        ($RPCService.call.calledWithMatch('webhook', 'remove', {
-            repo: 'myRepo',
-            owner: 'login'
-        })).should.be.equal(true);
         (homeCtrl.scope.errorMsg[0]).should.not.be.equal('This repository is already set up.');
     });
 
-    it('should delete db entry and webhook on remove for linked org', function () {
+    it('should delete db entry on remove for linked org', function () {
         homeCtrl = createCtrl();
         httpBackend.flush();
 
@@ -750,14 +667,11 @@ describe('Home Controller', function () {
         homeCtrl.scope.claOrgs = [org];
         homeCtrl.scope.remove(org);
 
-        ($RPCService.call.calledWithMatch('webhook', 'remove', {
-            org: 'octocat'
-        })).should.be.equal(true);
         ($RPCService.call.calledWithMatch('org', 'remove')).should.be.equal(true);
         (homeCtrl.scope.claOrgs.length).should.be.equal(0);
     });
 
-    it('should delete db entry and webhook on remove for linked repo', function () {
+    it('should delete db entry on remove for linked repo', function () {
         homeCtrl = createCtrl();
         httpBackend.flush();
 
@@ -772,7 +686,6 @@ describe('Home Controller', function () {
         homeCtrl.scope.claRepos = [repo];
         homeCtrl.scope.remove(repo);
 
-        ($RPCService.call.calledWithMatch('webhook', 'remove')).should.be.equal(true);
         ($RPCService.call.calledWithMatch('repo', 'remove')).should.be.equal(true);
         ($RPCService.call.calledWithMatch('repo', 'getAll')).should.be.equal(true);
     });

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -648,7 +648,8 @@ describe('', function () {
                 assert.deepEqual(args, {
                     repo: 'Hello-World',
                     owner: 'octocat',
-                    user: 'user'
+                    user: 'user',
+                    number: undefined
                 });
                 cb(null, true);
             });

--- a/src/tests/server/api/org.js
+++ b/src/tests/server/api/org.js
@@ -8,6 +8,7 @@ var sinon = require('sinon');
 var org = require('../../../server/services/org');
 var github = require('../../../server/services/github');
 var logger = require('../../../server/services/logger');
+var webhook = require('../../../server/api/webhook');
 var q = require('q');
 
 // test data
@@ -20,13 +21,28 @@ var org_api = require('../../../server/api/org');
 describe('org api', function () {
     var testErr = {};
     var testRes = {};
+    var req = null;
     beforeEach(function () {
+        req = {
+            args: {
+                orgId: 1,
+                org: 'myOrg',
+                gist: 'gistUrl'
+            },
+            user: {
+                token: 'abc'
+            }
+        };
         testErr.githubCall = null;
         testRes.githubCall = testData.orgs;
         testErr.githubCallGraphql = null;
         testRes.githubCallGraphql = { res: '', body: JSON.stringify(testData.graphqlUserOrgs) };
         testErr.githubGetMembership = null;
         testRes.githubGetMembership = { data: { role: 'admin' } };
+        testErr.webhook = {};
+        testRes.webhook = {};
+        testErr.org = {};
+        testRes.org = {};
 
         sinon.stub(github, 'callGraphql').callsFake(function (query, token, done) {
             assert(token);
@@ -46,10 +62,16 @@ describe('org api', function () {
             done(null, [{}, {}]);
         });
         sinon.stub(org, 'create').callsFake(function (args, done) {
-            done();
+            done(testErr.org.create, testRes.org.create);
+        });
+        sinon.stub(org, 'get').callsFake(function (args, done) {
+            done(testErr.org.get, testRes.org.get);
         });
         sinon.stub(logger, 'warn').callsFake(function (msg) {
             assert(msg);
+        });
+        sinon.stub(webhook, 'create').callsFake(function (args, done) {
+            done(testErr.webhook.create, testRes.webhook.create);
         });
     });
     afterEach(function () {
@@ -57,29 +79,68 @@ describe('org api', function () {
         github.callGraphql.restore();
         org.getMultiple.restore();
         org.create.restore();
+        org.get.restore();
         logger.warn.restore();
+        webhook.create.restore();
     });
 
-    it('should create new org via org service', function (it_done) {
-        var req = {
-            args: {
+    describe('create', function () {
+        it('should create new org via org service and create org webhook', function(it_done) {
+            org_api.create(req, function () {
+                assert(org.get.calledWith({
+                    orgId: 1,
+                    org: 'myOrg'
+                }));
+                assert(org.create.calledWith({
+                    orgId: 1,
+                    org: 'myOrg',
+                    gist: 'gistUrl',
+                    token: 'abc'
+                }));
+                assert(webhook.create.called);
+                it_done();
+            });
+        });
+
+        it('should send validation error if orgId, org, gist, token is absent when create org entry', function (it_done) {
+            req = {
+                args: {},
+                user: {}
+            };
+            org_api.create(req, function (err) {
+                assert(err);
+                assert(!org.get.called);
+                assert(!org.create.called);
+                assert(!webhook.create.called);
+                it_done();
+            });
+        });
+
+        it('should send duplicate org error if org already linked when create org entry', function (it_done) {
+            testErr.org.get = null;
+            testRes.org.get = {
                 orgId: 1,
                 org: 'myOrg',
                 gist: 'gistUrl'
-            },
-            user: {
-                token: 'abc'
-            }
-        };
-
-        org_api.create(req, function () {
-            org.create.calledWith({
-                orgId: 1,
-                org: 'myOrg',
-                gist: 'gistUrl',
-                token: 'abc'
+            };
+            org_api.create(req, function (err) {
+                assert(err === 'This org is already linked.');
+                assert(org.get.called);
+                assert(!org.create.called);
+                assert(!webhook.create.called);
+                it_done();
             });
-            it_done();
+        });
+
+        it('should not create hook when create org entry fail', function (it_done) {
+            testErr.org.create = 'Create org error';
+            org_api.create(req, function (err) {
+                assert(err);
+                assert(org.get.called);
+                assert(org.create.called);
+                assert(!webhook.create.called);
+                it_done();
+            });
         });
     });
 
@@ -114,6 +175,65 @@ describe('org api', function () {
             org_api.getForUser(req, function (err, orgs) {
                 assert(err);
                 assert(!orgs);
+                it_done();
+            });
+        });
+    });
+
+    describe('remove', function () {
+        beforeEach(function () {
+            req = {
+                args: {
+                    orgId: 1
+                }
+            };
+            testRes.org.remove = {
+                orgId: 1,
+                org: 'myOrg',
+            };
+            sinon.stub(org, 'remove').callsFake(function(args, done) {
+                done(testErr.org.remove, testRes.org.remove);
+            });
+            sinon.stub(webhook, 'remove').callsFake(function (args, done) {
+                done(testErr.webhook.remove, testRes.webhook.remove);
+            });
+        });
+
+        afterEach(function () {
+            org.remove.restore();
+            webhook.remove.restore();
+        });
+
+        it('should remove org entry and remove org webhook', function (it_done) {
+            org_api.remove(req, function () {
+                assert(org.remove.calledWith({
+                    orgId: 1,
+                    org: 'myOrg'
+                }));
+                assert(req.args.org);
+                assert(webhook.remove.called);
+                it_done();
+            });
+        });
+
+        it('should send error when remove org fail', function (it_done) {
+            testErr.org.remove = 'Remove org error';
+            org_api.remove(req, function (err) {
+                assert(err);
+                assert(org.remove.called);
+                assert(!webhook.remove.called);
+                it_done();
+            });
+        });
+
+        it('should send validation error when org or orgId is absent', function (it_done) {
+            req = {
+                args: {}
+            };
+            org_api.remove(req, function (err) {
+                assert(err);
+                assert(!org.remove.called);
+                assert(!webhook.remove.called);
                 it_done();
             });
         });

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -60,7 +60,8 @@ function stub() {
     testRes.repoServiceGet = {
         repoId: 123,
         gist: 'url/gistId',
-        token: 'abc'
+        token: 'abc',
+        sharedGist: false
     };
     testRes.repoServiceGetCommitters = [{
         name: 'login2'
@@ -97,6 +98,17 @@ function stub() {
         assert(msg);
     });
 
+    sinon.stub(github, 'call').callsFake(function (args, done) {
+        if (args.obj === 'pullRequests' && args.fun === 'get') {
+            return done(testErr.getPR, testRes.getPR);
+        } else if (args.obj === 'gists' && args.fun === 'get') {
+            if (testErr.gistData) {
+                return Promise.reject(testErr.gistData);
+            } else {
+                return Promise.resolve(testRes.gistData);
+            }
+        }
+    });
 }
 
 function restore() {
@@ -110,167 +122,56 @@ function restore() {
     logger.error.restore();
     logger.warn.restore();
     logger.info.restore();
+    github.call.restore();
 }
 
-describe('cla:get', function () {
-    var expClaFindOneArgs;
-    var resRepoServiceGet;
-
-    beforeEach(function () {
-        expClaFindOneArgs = {
-            repoId: 1296269,
-            user: 'login',
-            gist_url: 'gistUrl',
-            gist_version: 'xyz',
-            org_cla: false
-        };
-        resRepoServiceGet = testData.repo_from_db;
-        sinon.stub(repo_service, 'get').callsFake(function (args, done) {
-            done(null, resRepoServiceGet);
-        });
-        sinon.stub(CLA, 'findOne').callsFake(function (arg, done) {
-            done(null, true);
-        });
-    });
-    afterEach(function () {
-        CLA.findOne.restore();
-        repo_service.get.restore();
-    });
-
-    it('should find repoId if not given and get cla entry for the repo', function (it_done) {
-        var args = {
-            repo: 'Hello-World',
-            owner: 'octocat',
-            user: 'login',
-            gist: 'gistUrl',
-            gist_version: 'xyz'
-        };
-        cla.get(args, function () {
-            assert(repo_service.get.calledWithMatch({
-                owner: 'octocat',
-                repo: 'Hello-World'
-            }));
-            assert(CLA.findOne.calledWith(expClaFindOneArgs));
-            it_done();
-        });
-    });
-
-    it('should find cla with given repoId', function (it_done) {
-        var args = expClaFindOneArgs;
-        cla.get(args, function () {
-            assert(!repo_service.get.called);
-            it_done();
-        });
-    });
-
-    it('should find cla with repoId regardless of orgId', function (it_done) {
-        var args = {
-            orgId: 1,
-            repoId: 1296269,
-            user: 'login',
-            gist: 'gistUrl',
-            gist_version: 'xyz'
-        };
-        cla.get(args, function () {
-            assert(CLA.findOne.calledWith(expClaFindOneArgs));
-            it_done();
-        });
-    });
-
-    it('should find cla with orgId if repoId is not provided', function (it_done) {
-        var args = {
-            orgId: 1,
-            user: 'login',
-            gist: 'gistUrl',
-            gist_version: 'xyz'
-        };
-        var expArgs = {
-            ownerId: 1,
-            user: 'login',
-            gist_url: 'gistUrl',
-            gist_version: 'xyz',
-            org_cla: true
-        };
-        resRepoServiceGet = null;
-        cla.get(args, function () {
-            assert(CLA.findOne.calledWith(expArgs));
-            it_done();
-        });
-    });
-
-    it('should find a shared cla with given user', function (it_done) {
-        var args = {
-            orgId: 1,
-            repoId: 1296269,
-            user: 'login',
-            gist: 'gistUrl',
-            gist_version: 'xyz',
-            sharedGist: true
-        };
-        cla.get(args, function () {
-            assert(CLA.findOne.calledWith({
-                $or: [{
-                    user: args.user,
-                    gist_url: args.gist,
-                    gist_version: args.gist_version,
-                    repoId: args.repoId,
-                    org_cla: false
-                }, {
-                    user: args.user,
-                    gist_url: args.gist,
-                    gist_version: args.gist_version,
-                    repo: undefined,
-                    owner: undefined
-                }]
-            }));
-            it_done();
-        });
-    });
-});
-
 describe('cla:getLastSignature', function () {
+    var now = new Date();
+    var clock = null;
+
     beforeEach(function () {
         stub();
+        testRes.gistData = {
+            data: {
+                history: [{
+                    version: "xyz"
+                }]
+            }
+        };
+        clock = sinon.useFakeTimers(now.getTime());
     });
+
     afterEach(function () {
         restore();
-    });
-
-    it('should search for org clas if org is linked', function (it_done) {
-        testRes.repoServiceGet = null;
-        testRes.claFindOne = {
-            ownerId: 123,
-            user: 'login',
-            org_cla: true
-        };
-        testRes.orgServiceGet = {
-            orgId: 1,
-            org: 'org'
-        };
-        var args = {
-            repo: undefined,
-            owner: 'org'
-        };
-
-        cla.getLastSignature(args, function () {
-            assert.equal(CLA.findOne.calledWithMatch({
-                ownerId: 1,
-                org_cla: true
-            }), true);
-            it_done();
-        });
+        clock.restore();
     });
 
     it('should get cla entry for equal repo, user and gist url', function (it_done) {
         var args = {
             repo: 'myRepo',
-            owner: 'owner'
+            owner: 'owner',
+            user: 'user'
         };
 
         cla.getLastSignature(args, function () {
             assert.equal(CLA.findOne.calledWithMatch({
-                repoId: 123,
-                gist_url: 'url/gistId'
+                $or: [{
+                    user: 'user',
+                    gist_url: 'url/gistId',
+                    gist_version: 'xyz',
+                    repoId: 123,
+                    org_cla: false,
+                    created_at: { $lte: now },
+                    end_at: { $gt: now }
+                }, {
+                    user: 'user',
+                    gist_url: 'url/gistId',
+                    gist_version: 'xyz',
+                    repoId: 123,
+                    org_cla: false,
+                    created_at: { $lte: now },
+                    end_at: undefined
+                }]
             }), true);
             it_done();
         });
@@ -282,131 +183,96 @@ describe('cla:getLastSignature', function () {
             owner: 'owner',
             user: 'login'
         };
-        testRes.repoServiceGet = {
-            repoId: 123,
+        testRes.repoServiceGet.sharedGist = true;
+        cla.getLastSignature(args, function () {
+            assert(CLA.findOne.calledWith({
+                $or: [{
+                    user: args.user,
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    repoId: testRes.repoServiceGet.repoId,
+                    org_cla: false,
+                    created_at: { $lte: now },
+                    end_at: { $gt: now }
+                }, {
+                    user: args.user,
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    repoId: testRes.repoServiceGet.repoId,
+                    org_cla: false,
+                    created_at: { $lte: now },
+                    end_at: undefined
+                }, {
+                    user: args.user,
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    owner: undefined,
+                    repo: undefined,
+                    created_at: { $lte: now },
+                    end_at: { $gt: now }
+                }, {
+                    user: args.user,
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    owner: undefined,
+                    repo: undefined,
+                    created_at: { $lte: now },
+                    end_at: undefined
+                }]
+            }));
+            it_done();
+        });
+    });
+
+    it('should search a cla on current date and a pull request date when PR number is provided', function (it_done) {
+        var args = {
             repo: 'myRepo',
             owner: 'owner',
-            gist: 'url/gistId',
-            token: 'abc',
-            sharedGist: true
+            number: '1',
+            user: 'login'
+        };
+        var prCreateDateString = '1970-01-01T00:00:00.000Z';
+        var prCreateDate = new Date(prCreateDateString);
+        testErr.getPR = null;
+        testRes.getPR = {
+            created_at: prCreateDate
         };
         cla.getLastSignature(args, function () {
             assert(CLA.findOne.calledWith({
                 $or: [{
                     user: args.user,
                     gist_url: testRes.repoServiceGet.gist,
-                    repoId: testRes.repoServiceGet.repoId
+                    gist_version: 'xyz',
+                    repoId: testRes.repoServiceGet.repoId,
+                    org_cla: false,
+                    created_at: { $lte: now },
+                    end_at: { $gt: now }
                 }, {
-                    owner: undefined,
-                    repo: undefined,
                     user: args.user,
-                    gist_url: testRes.repoServiceGet.gist
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    repoId: testRes.repoServiceGet.repoId,
+                    org_cla: false,
+                    created_at: { $lte: now },
+                    end_at: undefined
+                }, {
+                    user: args.user,
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    repoId: testRes.repoServiceGet.repoId,
+                    org_cla: false,
+                    created_at: { $lte: prCreateDate },
+                    end_at: { $gt: prCreateDate }
+                }, {
+                    user: args.user,
+                    gist_url: testRes.repoServiceGet.gist,
+                    gist_version: 'xyz',
+                    repoId: testRes.repoServiceGet.repoId,
+                    org_cla: false,
+                    created_at: { $lte: prCreateDate },
+                    end_at: undefined
                 }]
             }));
-            it_done();
-        });
-    });
-});
-
-describe('cla:check', function () {
-    var testGistData = '{"url": "url", "files": {"xyFile": {"content": "some content"}}, "updated_at": "2011-06-20T11:34:15Z", "history": [{"version": "xyz"}]}';
-
-    beforeEach(function () {
-
-        stub();
-
-        sinon.stub(repo_service, 'getPRCommitters').callsFake(function (arg, done) {
-            assert(arg.number ? arg.number : arg.user);
-            done(testErr.repoServiceGetCommitters, testRes.repoServiceGetCommitters);
-        });
-
-        sinon.stub(github, 'call').callsFake(function (args, done) {
-            assert(args.token);
-            done(null, JSON.parse(testGistData));
-        });
-    });
-
-    afterEach(function () {
-        restore();
-
-        repo_service.getPRCommitters.restore();
-        github.call.restore();
-    });
-
-    it('should check for linked repo even when its org also linked', function (it_done) {
-        expArgs.claFindOne = {
-            repoId: '123',
-            user: 'login',
-            gist_url: 'url/gistId',
-            gist_version: 'xyz',
-            org_cla: false
-        };
-        testRes.repoServiceGet = {
-            repoId: '123',
-            repo: 'myRepo',
-            owner: 'owner',
-            gist: 'url/gistId',
-            token: 'abc'
-        };
-        testRes.claFindOne = {
-            id: 456,
-            gist_url: 'url/gistId',
-            created_at: '2012-06-20T11:34:15Z',
-            gist_version: 'xyz'
-        };
-
-        var args = {
-            orgId: 1,
-            repo: 'myRepo',
-            owner: 'owner',
-            user: 'login'
-        };
-
-        cla.check(args, function (err, result) {
-            assert(repo_service.get.called);
-            assert(!org_service.get.called);
-            assert(CLA.findOne.calledWith(expArgs.claFindOne));
-            assert.ifError(err);
-            assert(result);
-            it_done();
-        });
-    });
-
-    it('should check for linked org when the repo is NOT linked', function (it_done) {
-        expArgs.claFindOne = {
-            ownerId: 123,
-            user: 'login',
-            gist_url: 'url/gistId',
-            gist_version: 'xyz',
-            org_cla: true
-        };
-        testRes.orgServiceGet = {
-            orgId: 123,
-            gist: 'url/gistId',
-            token: 'abc'
-        };
-        testRes.claFindOne = {
-            id: 456,
-            gist_url: 'url/gistId',
-            created_at: '2012-06-20T11:34:15Z',
-            gist_version: 'xyz'
-        };
-        testRes.repoServiceGet = null;
-
-        var args = {
-            orgId: 1,
-            repo: 'myRepo',
-            owner: 'owner',
-            user: 'login'
-        };
-
-        cla.check(args, function (err, result) {
-            assert(repo_service.get.called);
-            assert(org_service.get.called);
-            assert(CLA.findOne.calledWith(expArgs.claFindOne));
-            sinon.assert.calledOnce(github.call);
-            assert.ifError(err);
-            assert(result);
             it_done();
         });
     });
@@ -418,265 +284,310 @@ describe('cla:check', function () {
             owner: 'owner',
             user: 'login'
         };
-        cla.check(args, function (err, signed) {
+        cla.getLastSignature(args, function (err, cla) {
             assert(!err);
-            assert(signed);
+            assert(cla);
+            it_done();
+        });
+    });
+
+    it('should send error if there is no linked repo or org', function (it_done) {
+        testErr.repoServiceGet = 'Repository not found in Database';
+        testErr.orgServiceGet = 'Organization not found in Database';
+        testRes.repoServiceGet = null;
+        testRes.orgServiceGet = null;
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            user: 'login'
+        };
+        cla.getLastSignature(args, function (err, cla) {
+            assert(err);
+            assert(!cla);
             it_done();
         });
     });
 
     it('should send error if getGist has an error', function (it_done) {
-        github.call.restore();
-        sinon.stub(github, 'call').callsFake(function (args, done) {
-            done('Error', null);
-        });
+        testErr.gistData = 'Error';
         var args = {
             repo: 'myRepo',
             owner: 'owner',
             user: 'login'
         };
+        cla.getLastSignature(args, function (err, cla) {
+            assert(err);
+            assert(!cla);
+            it_done();
+        });
+    });
 
-        cla.check(args, function (err, result) {
+    it('should send error if get pull request failed when pull request number is given', function (it_done) {
+        testErr.getPR = 'Error';
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            user: 'login',
+            number: '1'
+        };
+        cla.getLastSignature(args, function (err, cla) {
+            assert(err);
+            assert(!cla);
+            it_done();
+        });
+    });
+
+    it('should send error if user is not given', function (it_done) {
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner'
+        };
+        cla.getLastSignature(args, function (err, cla) {
+            assert(err);
+            assert(!cla);
+            it_done();
+        });
+    });
+});
+
+describe('cla:checkUserSignature', function () {
+    beforeEach(function () {
+        sinon.stub(cla, 'getLastSignature').callsFake(function (args, done) {
+            return done(null, {});
+        });
+    });
+
+    afterEach(function () {
+        cla.getLastSignature.restore();
+    });
+
+    it('should call get last signature for the user', function (it_done) {
+        var args = {
+            repo: 'repo',
+            owner: 'owner',
+            user: 'user'
+        };
+        cla.checkUserSignature(args, function (error, result) {
+            assert.ifError(error);
+            assert(result.signed);
+            assert(cla.getLastSignature.called);
+            it_done();
+        });
+    });
+});
+
+describe('cla:checkPullRequestSignatures', function () {
+    var now = new Date();
+    var clock = null;
+    beforeEach(function () {
+        stub();
+        testRes.gistData = {
+            data: {
+                url: 'url',
+                files: { xyFile: { content: 'some content' } },
+                updated_at: '2011-06-20T11:34:15Z',
+                history: [{ version: 'xyz' }]
+            }
+        };
+        testRes.repoServiceGet = {
+            repoId: '123',
+            repo: 'myRepo',
+            owner: 'owner',
+            gist: 'url/gistId',
+            sharedGist: false,
+            token: 'abc'
+        };
+        clock = sinon.useFakeTimers(now.getTime());
+        var prCreateDateString = '1970-01-01T00:00:00.000Z';
+        var prCreateDate = new Date(prCreateDateString);
+        testErr.getPR = null;
+        testRes.getPR = {
+            created_at: prCreateDate
+        };
+        sinon.stub(repo_service, 'getPRCommitters').callsFake(function (arg, done) {
+            done(testErr.repoServiceGetCommitters, testRes.repoServiceGetCommitters);
+        });
+    });
+
+    afterEach(function () {
+        restore();
+        repo_service.getPRCommitters.restore();
+        clock.restore();
+    });
+
+    it('should send error if there is no linked repo or org', function (it_done) {
+        testErr.repoServiceGet = 'Repository not found in Database';
+        testErr.orgServiceGet = 'Organization not found in Database';
+        testRes.repoServiceGet = null;
+        testRes.orgServiceGet = null;
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            number: '1'
+        };
+        cla.checkPullRequestSignatures(args, function (err, result) {
             assert(err);
             assert(!result);
+            it_done();
+        });
+    });
 
+    it('should send error if getGist has an error', function (it_done) {
+        testErr.gistData = 'Error';
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            number: '1'
+        };
+        cla.checkPullRequestSignatures(args, function (err, result) {
+            assert(err);
+            assert(!result);
             it_done();
         });
 
     });
 
-    it('should positive check whether user has already signed', function (it_done) {
-        expArgs.claFindOne = {
-            repoId: 123,
-            user: 'login',
-            gist_url: 'url/gistId',
-            gist_version: 'xyz',
-            org_cla: false
-        };
-        testRes.claFindOne = {
-            id: 456,
-            gist_url: 'url/gistId',
-            created_at: '2012-06-20T11:34:15Z',
-            gist_version: 'xyz'
-        };
-
+    it('should send error if get pull request failed', function (it_done) {
+        testErr.getPR = 'Error';
         var args = {
             repo: 'myRepo',
             owner: 'owner',
-            user: 'login'
+            number: '1'
         };
-
-        cla.check(args, function (err, result) {
-            assert(CLA.findOne.calledWith(expArgs.claFindOne));
-            assert.ifError(err);
-            assert(result);
-            it_done();
-        });
-    });
-
-    it('should negative check whether user has already signed', function (it_done) {
-        expArgs.claFindOne = {
-            repoId: 123,
-            user: 'login',
-            gist_url: 'url/gistId',
-            gist_version: 'xyz',
-            org_cla: false
-        };
-        testRes.claFindOne = null;
-
-        var args = {
-            repo: 'myRepo',
-            owner: 'owner',
-            user: 'login'
-        };
-
-        cla.check(args, function (err, result) {
-            assert(CLA.findOne.calledWith(expArgs.claFindOne));
-            assert.ifError(err);
+        cla.checkPullRequestSignatures(args, function (err, result) {
+            assert(err);
             assert(!result);
             it_done();
         });
     });
 
-    it('should positive check for pull request if pull request number given', function (it_done) {
-        testRes.claFindOne = {
-            id: 123,
-            gist_url: 'url/gistId',
-            created_at: '2012-06-20T11:34:15Z',
-            gist_version: 'xyz'
-        };
-
-        var args = {
-            repo: 'myRepo',
-            owner: 'owner',
-            number: 1
-        };
-
-        cla.check(args, function (err, result) {
-            assert.ifError(err);
-            assert(CLA.findOne.calledTwice);
-            assert(result);
-            it_done();
-        });
-    });
-
-    it('should negative check for pull request if pull request number given', function (it_done) {
-        CLA.findOne.restore();
-        sinon.stub(CLA, 'findOne').callsFake(function (arg, done) {
-            if (arg.user === 'login') {
-                done(null, {
-                    id: 123,
-                    gist_url: 'url/gistId',
-                    created_at: '2012-06-20T11:34:15Z',
-                    gist_version: 'xyz'
-                });
-            } else {
-                done(null, null);
-            }
-        });
-
-        var args = {
-            repo: 'myRepo',
-            owner: 'owner',
-            number: 1
-        };
-
-        cla.check(args, function (err, result) {
-            assert.ifError(err);
-            assert(!result);
-            it_done();
-        });
-    });
-
-    it('should return map of committers who has signed and who has not signed cla', function (it_done) {
-        CLA.findOne.restore();
-        sinon.stub(CLA, 'findOne').callsFake(function (arg, done) {
-            if (arg.user === 'login') {
-                done(null, {
-                    id: 123,
-                    user: 'login',
-                    gist_url: 'url/gistId',
-                    created_at: '2012-06-20T11:34:15Z',
-                    gist_version: 'xyz'
-                });
-            } else {
-                done(null, null);
-            }
-        });
-
-        var args = {
-            repo: 'myRepo',
-            owner: 'owner',
-            number: 1
-        };
-
-        cla.check(args, function (err, signed, map) {
-            assert.ifError(err);
-            assert(!signed);
-            assert.equal(map.not_signed[0], 'login2');
-            assert.equal(map.signed[0], 'login');
-            it_done();
-        });
-    });
-
-    it('should return map of committers containing list of users without github account', function (it_done) {
-        testRes.repoServiceGetCommitters = [{
-            name: 'login',
-            id: '123'
-        }, {
-            name: 'login2',
-            id: ''
-        }, {
-            name: 'login3',
-            id: ''
-        }];
-
-        CLA.findOne.restore();
-        sinon.stub(CLA, 'findOne').callsFake(function (arg, done) {
-            if (arg.user === 'login') {
-                done(null, {
-                    id: 123,
-                    user: 'login',
-                    gist_url: 'url/gistId',
-                    created_at: '2012-06-20T11:34:15Z',
-                    gist_version: 'xyz'
-                });
-            } else {
-                done(null, null);
-            }
-        });
-
-        var args = {
-            repo: 'myRepo',
-            owner: 'owner',
-            number: 1
-        };
-
-        cla.check(args, function (err, signed, map) {
-            assert.ifError(err);
-            assert(!signed);
-            assert.equal(map.unknown.length, 2);
-            assert.equal(map.unknown[0], 'login2');
-            assert.equal(map.not_signed[0], 'login2');
-            assert.equal(map.signed[0], 'login');
-            it_done();
-        });
-    });
-
-    it('should not fail if committers list is empty', function (it_done) {
+    it('should send error if committers list is empty', function (it_done) {
         testErr.repoServiceGetCommitters = 'err';
         testRes.repoServiceGetCommitters = undefined;
 
         var args = {
             repo: 'myRepo',
             owner: 'owner',
-            number: 1
+            number: '1'
         };
 
-        cla.check(args, function (err) {
+        cla.checkPullRequestSignatures(args, function (err) {
             assert(err);
             it_done();
         });
     });
 
-    it('should positive check when signed a shared gist before', function (it_done) {
+    it('should positive check if an repo has a null CLA', function (it_done) {
+        testRes.repoServiceGet.gist = undefined;
         var args = {
-            user: 'login',
             repo: 'myRepo',
             owner: 'owner',
-            gist: 'gist',
-            token: 'token'
+            number: '1'
         };
-        var linkedRepo = Object.assign({
-            repoId: 1,
-            sharedGist: true
-        }, args);
-        var version = '123';
-        testRes.orgServiceGet = null;
-        testRes.repoServiceGet = linkedRepo;
-        testGistData = JSON.stringify({
-            url: args.gist,
-            history: [{
-                version: version
-            }]
+        cla.checkPullRequestSignatures(args, function (err, result) {
+            assert(!err);
+            assert(result.signed);
+            it_done();
         });
-        cla.check(args, function (error) {
-            assert(repo_service.getGHRepo.called);
-            assert(CLA.findOne.calledWith({
-                $or: [{
-                    user: args.user,
-                    gist_url: args.gist,
-                    gist_version: version,
-                    org_cla: false,
-                    repoId: linkedRepo.repoId
-                }, {
-                    owner: undefined,
-                    repo: undefined,
-                    user: args.user,
-                    gist_url: args.gist,
-                    gist_version: version
-                }]
-            }));
+    });
+
+    it('should return map of committers who has signed, who has not signed and who has no github account', function (it_done) {
+        testRes.repoServiceGetCommitters = [{
+            name: 'login1',
+            id: '123'
+        }, {
+            name: 'login2',
+            id: '321'
+        }, {
+            name: 'login3',
+            id: ''
+        }];
+        CLA.findOne.restore();
+        sinon.stub(CLA, 'findOne').callsFake(function (arg, selector, options, done) {
+            if (!options && !done) {
+                done = selector;
+            }
+            if (arg.$or[0].user === 'login1') {
+                done(null, {
+                    id: 123,
+                    user: 'login1',
+                    gist_url: 'url/gistId',
+                    created_at: '2012-06-20T11:34:15Z',
+                    gist_version: 'xyz'
+                });
+            } else {
+                done(null, null);
+            }
+        });
+
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            number: '1'
+        };
+
+        cla.checkPullRequestSignatures(args, function (err, result) {
+            assert.ifError(err);
+            assert(!result.signed);
+            assert.equal(result.user_map.signed[0], 'login1');
+            assert.equal(result.user_map.not_signed[0], 'login2');
+            assert.equal(result.user_map.not_signed[1], 'login3');
+            assert.equal(result.user_map.unknown[0], 'login3');
+            it_done();
+        });
+    });
+});
+
+describe('cla.check', function () {
+    beforeEach(function () {
+        sinon.stub(cla, 'checkUserSignature').callsFake(function (args, done) {
+            return done(null, { signed: true });
+        });
+        sinon.stub(cla, 'checkPullRequestSignatures').callsFake(function (args, done) {
+            return done(null, { signed: true, user_map: {} });
+        });
+    });
+
+    afterEach(function () {
+        cla.checkUserSignature.restore();
+        cla.checkPullRequestSignatures.restore();
+    });
+
+    it('Should call checkUser when user is given', function (it_done) {
+        var args = {
+            repo: 'repo',
+            owner: 'owner',
+            user: 'user'
+        };
+        cla.check(args, function (error, done) {
+            assert(cla.checkUserSignature.called);
+            assert(!cla.checkPullRequestSignatures.called);
+            it_done();
+        });
+    });
+
+    it('Should call checkPullRequest when user is NOT given and pull request number is given', function (it_done) {
+        var args = {
+            repo: 'repo',
+            owner: 'owner',
+            number: '1'
+        };
+        cla.check(args, function (error, done) {
+            assert(cla.checkPullRequestSignatures.called);
+            assert(!cla.checkUserSignature.called);
+            it_done();
+        });
+    });
+
+    it('Should send error if user or pull request number is NOT given', function (it_done) {
+        var args = {
+            repo: 'repo',
+            owner: 'owner'
+        };
+        cla.check(args, function (error, done) {
+            assert(error);
+            assert(!cla.checkPullRequestSignatures.called);
+            assert(!cla.checkUserSignature.called);
             it_done();
         });
     });
@@ -684,9 +595,9 @@ describe('cla:check', function () {
 
 describe('cla:sign', function () {
     var testArgs = {};
-    var testGistData = '{"url": "url", "files": {"xyFile": {"content": "some content"}}, "updated_at": "2011-06-20T11:34:15Z", "history": [{"version": "xyz"}]}';
 
     beforeEach(function () {
+        stub();
         testArgs.claSign = {
             repo: 'myRepo',
             owner: 'owner',
@@ -694,18 +605,12 @@ describe('cla:sign', function () {
             userId: 3
         };
 
-        testRes.claGet = {
-            id: 123,
-            gist_url: 'url/gistId',
-            created_at: '2011-06-20T11:34:15Z',
-            gist_version: 'xyz'
-        };
-
         testRes.repoServiceGet = {
             repoId: '123',
             repo: 'myRepo',
             owner: 'owner',
             gist: 'url/gistId',
+            sharedGist: false,
             token: 'abc'
         };
 
@@ -713,21 +618,22 @@ describe('cla:sign', function () {
             orgId: '1',
             org: 'test_org',
             gist: 'url/gistId',
+            sharedGist: false,
             token: 'abc'
         };
 
-        sinon.stub(github, 'call').callsFake(function (args, done) {
-            assert(args.token);
-            done(null, JSON.parse(testGistData));
-        });
-
-        sinon.stub(cla, 'get').callsFake(function (args, done) {
-            if (args.user !== 'login') {
-                done(null, testRes.claGet);
-            } else {
-                done(null, undefined);
+        testRes.claFindOne = null;
+        testRes.gistData = {
+            data: {
+                url: 'url',
+                files: { xyFile: { content: 'some content' } },
+                updated_at: '2011-06-20T11:34:15Z',
+                history: [{ version: 'xyz' }]
             }
-        });
+        };
+        testErr.orgServiceGet = null;
+        testErr.repoServiceGet = null;
+        testErr.repoServiceGet = null;
 
         sinon.stub(CLA, 'create').callsFake(function (args, done) {
             assert(args);
@@ -740,39 +646,17 @@ describe('cla:sign', function () {
             assert(args.gist_version);
             done(testErr.claCreate, testRes.claCreate);
         });
-
-        sinon.stub(org_service, 'get').callsFake(function (args, done) {
-            assert(args);
-            done(null, testRes.orgServiceGet);
-        });
-
-        sinon.stub(repo_service, 'get').callsFake(function (args, done) {
-            assert(args);
-            done(null, testRes.repoServiceGet);
-        });
-
-        sinon.stub(repo_service, 'getGHRepo').callsFake(function (args, done) {
-            done(null, testData.repo);
-        });
-
-        sinon.stub(statusService, 'update').callsFake(function (args) {
-            assert(args.signed);
-        });
     });
 
     afterEach(function () {
-        cla.get.restore();
+        restore();
         CLA.create.restore();
-        org_service.get.restore();
-        repo_service.get.restore();
-        repo_service.getGHRepo.restore();
-        statusService.update.restore();
-        github.call.restore();
     });
 
     it('should store signed cla data for repo if not signed yet', function (it_done) {
         cla.sign(testArgs.claSign, function () {
             assert(CLA.create.called);
+            assert(CLA.findOne.called);
             assert(!org_service.get.called);
             it_done();
         });
@@ -782,25 +666,11 @@ describe('cla:sign', function () {
         testRes.repoServiceGet = null;
         cla.sign(testArgs.claSign, function () {
             assert(CLA.create.called);
+
             assert(CLA.create.calledWithMatch({
                 gist_url: 'url/gistId'
             }));
             assert(org_service.get.called);
-
-            it_done();
-        });
-    });
-
-    it('should not call getLinkedItem if there is an item provided', function (it_done) {
-        let args = JSON.parse(JSON.stringify(testArgs.claSign));
-        args.item = testRes.repoServiceGet;
-        cla.sign(args, function () {
-            assert(CLA.create.called);
-            assert(CLA.create.calledWithMatch({
-                gist_url: 'url/gistId'
-            }));
-            assert(!org_service.get.called);
-            assert(!repo_service.get.called);
 
             it_done();
         });
@@ -824,6 +694,7 @@ describe('cla:sign', function () {
 
     it('should do nothing if user has already signed', function (it_done) {
         testArgs.claSign.user = 'signedUser';
+        testRes.claFindOne = {};
 
         cla.sign(testArgs.claSign, function () {
             assert.equal(CLA.create.called, false);
@@ -993,13 +864,12 @@ describe('cla:getAll', function () {
     beforeEach(function () {
         sinon.stub(CLA, 'find').callsFake(function (arg, prop, options, done) {
             assert(arg);
-            assert(arg.gist_url);
             var resp = [{
                 id: 2,
                 created_at: '2011-06-20T11:34:15Z',
                 gist_version: 'xyz'
             }];
-            if (!arg.gist_version) {
+            if (!arg.$or[0].gist_version) {
                 resp.push({
                     id: 1,
                     created_at: '2010-06-20T11:34:15Z',
@@ -1025,8 +895,11 @@ describe('cla:getAll', function () {
 
         cla.getAll(args, function (err, arr) {
             assert.ifError(err);
-            assert.equal(CLA.find.calledWithMatch({
-                ownerId: 1
+            assert.equal(CLA.find.calledWith({
+                $or: [{
+                    ownerId: 1,
+                    gist_url: 'gistUrl'
+                }]
             }), true);
             assert.equal(arr.length, 2);
             assert.equal(arr[0].id, 2);
@@ -1046,7 +919,10 @@ describe('cla:getAll', function () {
         cla.getAll(args, function (err, arr) {
             assert.ifError(err);
             assert.equal(CLA.find.calledWithMatch({
-                repoId: testData.repo.id
+                $or: [{
+                    repoId: testData.repo.id,
+                    gist_url: 'gistUrl'
+                }]
             }), true);
 
             assert.equal(arr.length, 2);
@@ -1213,6 +1089,19 @@ describe('cla:getGist', function () {
 
 describe('cla:getLinkedItem', function () {
     beforeEach(function () {
+        testRes.repoServiceGet = {
+            repoId: '1',
+            repo: 'Hello-World',
+            owner: 'octocat',
+            gist: 'url/gistId',
+            token: 'abc'
+        };
+        testRes.orgServiceGet = {
+            orgId: '1',
+            org: 'octocat',
+            gist: 'url/gistId',
+            token: 'abc'
+        };
         testErr.repoServiceGetGHRepo = null;
         config.server.github.token = 'token';
         sinon.stub(repo_service, 'getGHRepo').callsFake(function (args, done) {
@@ -1298,6 +1187,87 @@ describe('cla:getLinkedItem', function () {
             assert(org_service.get.called);
             assert(!repo_service.get.called);
             assert(!repo_service.getGHRepo.called);
+            it_done();
+        });
+    });
+});
+
+describe('cla:terminate', function () {
+    var testArgs = {};
+
+    beforeEach(function () {
+        stub();
+        testRes.repoServiceGet = {
+            repoId: '123',
+            repo: 'myRepo',
+            owner: 'owner',
+            gist: 'url/gistId',
+            sharedGist: false,
+            token: 'abc'
+        };
+        testErr.orgServiceGet = null;
+        testErr.repoServiceGet = null;
+        testErr.repoServiceGet = null;
+        testRes.gistData = {
+            data: {
+                history: [{
+                    version: "xyz"
+                }]
+            }
+        };
+    });
+
+    afterEach(function () {
+        restore();
+    });
+
+    it('should send error when terminate a null cla', function (it_done) {
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            token: 'test_token'
+        };
+        testRes.repoServiceGet.gist = undefined;
+        cla.terminate(args, function (error, dbCla) {
+            assert(error);
+            assert(!dbCla);
+            it_done();
+        });
+    });
+
+    it('should send error when cannot find a signed cla to terminate', function (it_done) {
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            token: 'test_token'
+        };
+        testRes.claFindOne = null;
+        cla.terminate(args, function (error, dbCla) {
+            assert(error);
+            assert(!dbCla);
+            it_done();
+        });
+    });
+
+    it('should successfully update the end_at when terminate a cla', function (it_done) {
+        var args = {
+            repo: 'myRepo',
+            owner: 'owner',
+            user: 'user',
+            token: 'test_token'
+        };
+        testRes.claFindOne = {
+            repoId: 'repoId',
+            gist_url: 'url/gistId',
+            created_at: '2012-06-20T11:34:15Z',
+            gist_version: 'xyz',
+            save: function () {
+                return Promise.resolve('Success');
+            }
+        };
+        cla.terminate(args, function (error, dbCla) {
+            assert.ifError(error);
+            assert(dbCla);
             it_done();
         });
     });

--- a/src/tests/server/services/org.js
+++ b/src/tests/server/services/org.js
@@ -87,21 +87,22 @@ describe('org:getMultiple', function () {
     });
 });
 describe('org:remove', function () {
-    afterEach(function () {
-        Org.remove.restore();
-    });
-
-    it('should find org entry ', function (it_done) {
-        sinon.stub(Org, 'remove').callsFake(function (args, done) {
+    beforeEach(function () {
+        sinon.stub(Org, 'findOneAndRemove').callsFake(function(args, done) {
             assert(args.orgId);
             done(null, {});
         });
+    });
 
+    afterEach(function() {
+        Org.findOneAndRemove.restore();
+    });
+
+    it('should find org entry ', function(it_done) {
         var args = {
             orgId: testData.orgs[0].id,
             org: testData.orgs[0].login,
         };
-
         org.remove(args, function (err, org) {
             assert.ifError(err);
             assert(org);

--- a/src/tests/server/services/repo.js
+++ b/src/tests/server/services/repo.js
@@ -503,7 +503,7 @@ describe('repo:getPRCommitters', function () {
             assert.equal(orgService.get.calledWith({
                 orgId: 1
             }), true);
-            assert.equal(Repo.findOne.called, false);
+            assert(Repo.findOne.called);
             sinon.assert.called(github.callGraphql);
 
             it_done();

--- a/src/tests/server/services/status.js
+++ b/src/tests/server/services/status.js
@@ -277,7 +277,7 @@ var testStatusesFailure = [
     }
 ];
 
-describe('status:update', function () {
+describe('status', function () {
     var githubCallPRGet, githubCallStatusGet, assertFunction;
     beforeEach(function () {
         githubCallPRGet = {
@@ -310,165 +310,225 @@ describe('status:update', function () {
         github.call.restore();
     });
 
-    it('should create comment with admin token', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc'
-        };
+    describe('update', function () {
+        it('should create comment with admin token', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc'
+            };
 
-        status.update(args, function () {
-            assert.equal(github.call.callCount, 4);
-            it_done();
-        });
-    });
-
-    it('should create status pending if not signed', function (it_done) {
-        assertFunction = function (args) {
-            assert.equal(args.arg.state, 'pending');
-            assert.equal(args.arg.context, 'license/cla');
-
-        };
-        githubCallStatusGet.data = testStatusesSuccess;
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc'
-        };
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
-        });
-    });
-
-    it('should not update status if no pull request found', function (it_done) {
-        githubCallPRGet.err = 'error';
-        githubCallPRGet.data = null;
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc'
-        };
-
-        status.update(args);
-
-        assert(github.call.calledOnce);
-        it_done();
-    });
-
-    it('should not update status if no pull request found', function (it_done) {
-        githubCallPRGet.data = {
-            message: 'Not found'
-        };
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc'
-        };
-
-        status.update(args);
-
-        assert(github.call.calledOnce);
-        it_done();
-    });
-
-    it('should not load PR if sha is provided', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
-        });
-    });
-
-    it('should use old and new context if there is already a status with this context', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
-        // assertFunction = function (args) {
-        //     assert.equal(args.arg.context, 'licence/cla');
-        // };
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
+            status.update(args, function () {
+                assert.equal(github.call.callCount, 4);
+                it_done();
+            });
         });
 
-    });
+        it('should create status pending if not signed', function (it_done) {
+            assertFunction = function (args) {
+                assert.equal(args.arg.state, 'pending');
+                assert.equal(args.arg.context, 'license/cla');
 
-    it('should not update status if it has not changed', function (it_done) {
-        githubCallStatusGet.data = testStatusesSuccess;
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
+            };
+            githubCallStatusGet.data = testStatusesSuccess;
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc'
+            };
 
-        status.update(args, function () {
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+        });
+
+        it('should not update status if no pull request found', function (it_done) {
+            githubCallPRGet.err = 'error';
+            githubCallPRGet.data = null;
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc'
+            };
+
+            status.update(args);
+
             assert(github.call.calledOnce);
-            assert(github.call.calledWithMatch({ obj: 'repos', fun: 'getStatuses' }));
             it_done();
         });
 
+        it('should not update status if no pull request found', function (it_done) {
+            githubCallPRGet.data = {
+                message: 'Not found'
+            };
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc'
+            };
+
+            status.update(args);
+
+            assert(github.call.calledOnce);
+            it_done();
+        });
+
+        it('should not load PR if sha is provided', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+        });
+
+        it('should use old and new context if there is already a status with this context', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+            // assertFunction = function (args) {
+            //     assert.equal(args.arg.context, 'licence/cla');
+            // };
+
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+
+        });
+
+        it('should not update status if it has not changed', function (it_done) {
+            githubCallStatusGet.data = testStatusesSuccess;
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+
+            status.update(args, function () {
+                assert(github.call.calledOnce);
+                assert(github.call.calledWithMatch({ obj: 'repos', fun: 'getStatuses' }));
+                it_done();
+            });
+
+        });
+
+        it('should update status if there are no old ones', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: false,
+                token: 'abc',
+                sha: 'sha1'
+            };
+            githubCallStatusGet.data = null;
+
+            status.update(args, function () {
+                assert(github.call.calledTwice);
+                it_done();
+            });
+
+        });
+
+        it('should update statuses of all contexts if there are both (licenCe and licenSe)', function (it_done) {
+            var args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                signed: true,
+                token: 'abc',
+                sha: 'sha1'
+            };
+            githubCallStatusGet.data = testStatusesFailure;
+
+            status.update(args, function () {
+                assert(github.call.calledThrice);
+                it_done();
+            });
+
+        });
     });
 
-    it('should update status if there are no old ones', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: false,
-            token: 'abc',
-            sha: 'sha1'
-        };
-        githubCallStatusGet.data = null;
+    describe('delete', function () {
+        var args, expArgsGithubPullRequests;
+        beforeEach(function () {
+            args = {
+                owner: 'octocat',
+                repo: 'Hello-World',
+                number: 1,
+                token: 'abc'
+            };
 
-        status.update(args, function () {
-            assert(github.call.calledTwice);
-            it_done();
+            expArgsGithubPullRequests = {
+                createStatus: {
+                    obj: 'repos',
+                    fun: 'createStatus',
+                    arg: {
+                        owner: args.owner,
+                        repo: args.repo,
+                        sha: githubCallPRGet.data.head.sha,
+                        state: 'success',
+                        description: 'No need to sign Contributor License Agreement.',
+                        target_url: undefined,
+                        context: 'license/cla',
+                        noCache: true
+                    },
+                    token: args.token
+                },
+                get: {
+                    obj: 'pullRequests',
+                    fun: 'get',
+                    arg: {
+                        owner: args.owner,
+                        repo: args.repo,
+                        number: args.number,
+                        noCache: true
+                    },
+                    token: args.token
+                }
+            };
         });
 
-    });
-
-    it('should update statuses of all contexts if there are both (licenCe and licenSe)', function (it_done) {
-        var args = {
-            owner: 'octocat',
-            repo: 'Hello-World',
-            number: 1,
-            signed: true,
-            token: 'abc',
-            sha: 'sha1'
-        };
-        githubCallStatusGet.data = testStatusesFailure;
-
-        status.update(args, function () {
-            assert(github.call.calledThrice);
-            it_done();
+        it('should delete status when sha is not provided', function (it_done) {
+            status.delete(args, function (error, done) {
+                assert(github.call.calledWith(expArgsGithubPullRequests.get));
+                assert(github.call.calledWith(expArgsGithubPullRequests.createStatus));
+                it_done();
+            });
         });
 
+        it('should delete status when sha is provided', function (it_done) {
+            args.sha = githubCallPRGet.data.head.sha;
+            status.delete(args, function (error, done) {
+                assert(!github.call.calledWith(expArgsGithubPullRequests.get));
+                assert(github.call.calledWith(expArgsGithubPullRequests.createStatus));
+                it_done();
+            });
+        });
     });
 });

--- a/src/tests/server/webhooks/pull_request.js
+++ b/src/tests/server/webhooks/pull_request.js
@@ -540,7 +540,7 @@ describe('webhook pull request', function () {
 
 	it('should NOT try to access org cla if repo cla is exist', function (it_done) {
 		pull_request(test_req, res);
-		this.timeout(20);
+		this.timeout(100);
 		setTimeout(function () {
 			assert(repoService.get.called);
 			assert(!orgService.get.called);

--- a/src/tests/server/webhooks/pull_request.js
+++ b/src/tests/server/webhooks/pull_request.js
@@ -499,6 +499,30 @@ describe('webhook pull request', function () {
         }, 8);
     });
 
+    it('should store PR if the PR is from an repo that is not stored before', function (it_done) {
+        testUser.requests = [{
+            repo: 'Another Repo',
+            owner: 'octocat',
+            numbers: [1]
+        }];
+        test_req.args.number = 1;
+        cla.check.restore();
+
+        sinon.stub(cla, 'check').callsFake(function (args, done) {
+            done(null, false, {
+                not_signed: ['test_user']
+            });
+        });
+
+        pull_request(test_req, res);
+        this.timeout(100);
+        setTimeout(function () {
+            sinon.assert.called(User.findOne);
+            assert(testUserSaved);
+            it_done();
+        }, 8);
+    });
+
 	it('should update status of pull request if signed', function (it_done) {
 		cla.check.restore();
 		sinon.stub(cla, 'check').callsFake(function (args, done) {


### PR DESCRIPTION
Hello SAP team, thank you so much for your awesome project. Microsoft Open Source Program Office team has adopted and modified it to protect all Microsoft repos successfully. Now I have a list of features that want to contribute back to help the CLA-Assistant works properly for larger scale.
We are happy to break this big PR into multiple PRs based on features.

Feature list:
1. Overridden CLA and Null CLA for linked orgs
Because there are some repos in an org that don’t share the same CLA with their org. An override CLA for those repos is necessary.
What’s more, some repos in an org may not need CLA at all. So a null type CLA is introduced. It's better than the exempt list because it can be managed like other CLA, which means we can delete a null CLA repo without relinking the org.

2. Enable terminate signed CLA
To mark a previous CLA signature as terminated.

3. Skip CLA for a small contribution.
In order to minimize the friction to make a contribution, CLA is not required when a pull request is relatively small as defined by UI settings.

4. Expose add/terminate/check a CLA and link/unlink a repo/org API
The CLA-Assistant is just one part of the open source management system. Expose APIs for other micro services.

5. Add submitter mode
Only require the PR submitter to sign a CLA instead of all the committers. It can be changed in the configuration settings.

6. Reduce GitHub call
I have some changes that reduce token usage by around 40%

7. Minor UI changes
8. Some bugfixes