### PR TITLE
Add whitelisting bots section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ We're no lawyers, but we can suggest using http://contributoragreements.org/ for
 #### Who can I contact for help?
 In case of problems or any further questions, please open an issue in GitHub. We always appreciate helpful tips and support for the project.
 
+#### Can I whitelist bot users?
+Since there's no way for bot users (such as Dependabot or Greenkeeper) to sign a CLA, you may want to whitelist them. You can do so by importing their names (in this case `dependabot[bot]` and `greenkeeper[bot]`) in the CLA assistant dashboard.
+
 
 Setup your own instance of CLA assistant
 ==============================


### PR DESCRIPTION
We've had a couple of Dependabot users struggle to whitelist Dependabot in CLA Assistant.

I'd love https://github.com/cla-assistant/cla-assistant/issues/173 to be implemented, but in the meantime it would be good to have some simple advice in the readme. The instructions here are taken from https://github.com/greenkeeperio/greenkeeper/issues/236 (updated for the comments in [this PR](https://github.com/wireapp/wire-web-packages/pull/21)).