### PR TITLE
3 bugfixes and 2 features

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -36,7 +36,7 @@ module.exports = {
             commit_bots: ['web-flow'],
 
             //delay reaction on webhook
-            enforceDelay: process.env.GITHUB_DELAY || 1000 * 5,
+            enforceDelay: parseInt(process.env.GITHUB_DELAY || '5000', 10),
 
             //slow down API calls in order to avoid abuse rate limit
             timeToWait: process.env.GITHUB_TIME_TO_WAIT || 1000
@@ -99,6 +99,10 @@ module.exports = {
             ]
         },
 
+        feature_flag: {
+            required_signees: process.env.REQUIRED_SIGNEES || '',
+        },
+
         static: [
             path.join(__dirname, 'bower'),
             path.join(__dirname, 'client')
@@ -131,7 +135,7 @@ module.exports = {
 
         passport: [
             path.join(__dirname, 'server', 'passports', '*.js')
-        ]
+        ],
 
     },
 

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -192,7 +192,11 @@ function updateUsersPullRequests(args) {
         async.series(user.requests.map((pullRequests, index) => {
             return function (callback) {
                 return cla.getLinkedItem({ repo: pullRequests.repo, owner: pullRequests.owner }, (err, linkedItem) => {
-                    if (linkedItem && (linkedItem.owner === item.owner && linkedItem.repo === item.repo) || linkedItem.org === item.org || (linkedItem.gist === item.gist && item.sharedGist === true && linkedItem.sharedGist === true)) {
+                    if (!linkedItem) {
+                        needRemove.push(index);
+                        return callback();
+                    }
+                    if ((linkedItem.owner === item.owner && linkedItem.repo === item.repo) || linkedItem.org === item.org || (linkedItem.gist === item.gist && item.sharedGist === true && linkedItem.sharedGist === true)) {
                         needRemove.push(index);
                         validateUserPRs(pullRequests.repo, pullRequests.owner, linkedItem.gist, linkedItem.sharedGist, pullRequests.numbers, linkedItem.token);
                     }

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -169,15 +169,20 @@ function updateUsersPullRequests(args) {
         if (err || !user || !user.requests || user.requests.length < 1) {
             let req = {
                 args: {
-                    repo: args.repo,
-                    owner: args.owner,
                     gist: args.item.gist,
-                    sharedGist: args.item.sharedGist,
                     token: args.token
                 }
             };
-            ClaApi.validatePullRequests(req, () => { });
-            return;
+            if (args.item.sharedGist) {
+                return ClaApi.validateSharedGistItems(req, () => { });
+            } else if (args.item.org) {
+                req.args.org = args.item.org;
+                return ClaApi.validateOrgPullRequests(req, () => { });
+            } else {
+                req.args.repo = args.repo;
+                req.args.owner = args.owner;
+                return ClaApi.validatePullRequests(req, () => { });
+            }
         }
         prepareForValidation(args.item, user);
     });

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -344,6 +344,7 @@ let ClaApi = {
     getLastSignature: function (req, done) {
         let args = req.args;
         args.user = req.user.login;
+        args.userId = req.user.id;
         cla.getLastSignature(args, done);
     },
 
@@ -582,7 +583,8 @@ let ClaApi = {
             repo: req.args.repo,
             owner: req.args.owner,
             number: req.args.number,
-            user: req.user.login
+            user: req.user.login,
+            userId: req.user.id
         };
 
         cla.check(args, done);

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -121,11 +121,10 @@ module.exports = function () {
         if (gist_version) {
             sharedGistCondition.gist_version = gist_version;
         }
-        if (user) {
-            sharedGistCondition.user = user;
-        }
         if (userId) {
             sharedGistCondition.userId = userId;
+        } else if (user) {
+            sharedGistCondition.user = user;
         }
         return sharedGistCondition;
     };
@@ -276,7 +275,6 @@ module.exports = function () {
             deffered.reject(error);
         }
         let query = {
-            user: user,
             gist_url: gist_url,
             org_cla: !!orgId
         };
@@ -286,11 +284,14 @@ module.exports = function () {
         if (orgId) {
             query.ownerId = orgId;
         }
-        if (userId) {
-            query.userId = userId;
-        }
         if (gist_version) {
             query.gist_version = gist_version;
+        }
+        if (userId) {
+            query.userId = userId;
+        } else {
+            logger.info({ name: 'The userId is empty.', user: user, repoId: repoId, orgId: orgId });
+            query.user = user;
         }
         query = updateQuery(query, sharedGist, date);
         CLA.findOne(query, {}, {
@@ -300,6 +301,14 @@ module.exports = function () {
         }, function (error, cla) {
             if (error) {
                 return deferred.reject(error);
+            }
+            if (cla && cla.user !== user) {
+                cla.user = user;
+                return cla.save().then(function (updatedCla) {
+                    deferred.resolve(updatedCla);
+                }).catch(function (err) {
+                    deferred.reject(err);
+                });
             }
             deferred.resolve(cla);
         });

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -464,8 +464,6 @@ module.exports = function () {
                     }).then(signees => {
                         return checkAll(signees, item.repoId, item.orgId, item.sharedGist, item.gist, args.gist_version, args.onDates).then(function (result) {
                             done(null, result);
-                        }).catch(function (err) {
-                            done(err);
                         });
                     });
                 });

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -89,7 +89,7 @@ let githubService = {
                 meta.scopes = res.meta['x-oauth-scopes'];
                 if (res.meta['x-ratelimit-remaining'] < 100) {
                     setRateLimit(call.token, res.meta['x-ratelimit-reset']);
-                    console.log('rate limit exceeds for ', call);
+                    logger.info('rate limit exceeds for ', call);
                 }
                 delete res.meta;
             } catch (ex) {

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -85,7 +85,7 @@ let githubService = {
             let meta = {};
             try {
                 meta.link = res.meta.link;
-                meta.hasMore = !!github.hasNextPage(res.meta.link);
+                meta.hasMore = !!meta.link && !!github.hasNextPage(res.meta.link);
                 meta.scopes = res.meta['x-oauth-scopes'];
                 if (res.meta['x-ratelimit-remaining'] < 100) {
                     setRateLimit(call.token, res.meta['x-ratelimit-reset']);

--- a/src/server/services/status.js
+++ b/src/server/services/status.js
@@ -44,7 +44,7 @@ var getStatuses = function (args, done) {
 var getCombinedStatus = function (args, done) {
     github.call({
         obj: 'repos',
-        fun: 'getCombinedStatus',
+        fun: 'getCombinedStatusForRef',
         arg: {
             owner: args.owner,
             repo: args.repo,

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -656,6 +656,7 @@ describe('', function () {
                     repo: 'Hello-World',
                     owner: 'octocat',
                     user: 'user',
+                    userId: 3,
                     number: undefined
                 });
                 cb(null, true);

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -607,6 +607,29 @@ describe('', function () {
                 it_done();
             });
         });
+
+        it('should delete stored pull requests from unlinked org or repo', function (it_done) {
+            testUser.requests.push({
+                repo: 'Not linked anymore',
+                owner: 'Test',
+                numbers: [1]
+            });
+            cla.getLinkedItem.restore();
+            sinon.stub(cla, 'getLinkedItem').callsFake(function (args, cb) {
+                if (args.owner === 'octocat' && args.repo === 'Hello-World') {
+                    cb(error.cla.getLinkedItem, resp.cla.getLinkedItem);
+                } else {
+                    cb(null, null);
+                }
+            });
+            cla_api.sign(req, function (err, res) {
+                assert.ifError(err);
+                assert(!testUser.requests.length);
+                sinon.assert.calledOnce(cla.check);
+
+                it_done();
+            });
+        });
     });
 
     describe('cla api', function () {

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -509,6 +509,32 @@ describe('', function () {
             });
         });
 
+        it('should update status of all open pull requests for the repos and orgs that shared the same gist if user model has no requests stored', function (it_done) {
+            testUser.requests = undefined;
+            resp.cla.getLinkedItem = Object({
+                sharedGist: true
+            }, resp.cla.getLinkedItem);
+            sinon.stub(cla_api, 'validateSharedGistItems').callsFake(() => { });
+            cla_api.sign(req, function (err, res) {
+                assert.ifError(err);
+                assert(cla_api.validateSharedGistItems.called);
+                cla_api.validateSharedGistItems.restore();
+                it_done();
+            });
+        });
+
+        it('should update status of all open pull requests for the org that when linked an org if user model has no requests stored', function (it_done) {
+            testUser.requests = undefined;
+            resp.cla.getLinkedItem = testData.org_from_db;
+            sinon.stub(cla_api, 'validateOrgPullRequests').callsFake(() => { });
+            cla_api.sign(req, function (err, res) {
+                assert.ifError(err);
+                assert(cla_api.validateOrgPullRequests.called);
+                cla_api.validateOrgPullRequests.restore();
+                it_done();
+            });
+        });
+
         it('should comment with user_map if it is given', function (it_done) {
             cla.check.restore();
             prService.editComment.restore();

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -930,7 +930,9 @@ describe('cla:sign', function () {
 
     it('should do nothing if user has already signed', function (it_done) {
         testArgs.claSign.user = 'signedUser';
-        testRes.claFindOne = {};
+        testRes.claFindOne = {
+            user: 'signedUser'
+        };
 
         cla.sign(testArgs.claSign, function () {
             assert.equal(CLA.create.called, false);
@@ -944,6 +946,19 @@ describe('cla:sign', function () {
 
         cla.sign(testArgs.claSign, function (err, result) {
             assert(err);
+            assert(!result);
+            it_done();
+        });
+    });
+
+    it('should send error message when a repo linked with an Null CLA', function (it_done) {
+        testErr.claCreate = 'any DB error';
+        testRes.claCreate = null;
+        testRes.repoServiceGet.gist = null;
+
+        cla.sign(testArgs.claSign, function (err, result) {
+            assert(err);
+            assert(err.code === 200);
             assert(!result);
             it_done();
         });

--- a/src/tests/server/services/status.js
+++ b/src/tests/server/services/status.js
@@ -315,7 +315,7 @@ describe('status', function () {
             } else if (args.obj === 'repos' && args.fun === 'getStatuses') {
                 assert.equal(args.token, 'abc');
                 done(githubCallStatusGet.err, githubCallStatusGet.data);
-            } else if (args.obj === 'repos' && args.fun === 'getCombinedStatus') {
+            } else if (args.obj === 'repos' && args.fun === 'getCombinedStatusForRef') {
                 done(githubCallCombinedStatus.err, githubCallCombinedStatus.data);
             } else {
                 assert.equal(args.token, 'abc');


### PR DESCRIPTION
Bugfixes:
1. New GitHub node package changes getting combined status API from 'getCombinedStatus' to 'getCombinedStatusForRef

2. When the input is undefined or null, hasNextPage() API of GitHub node package will throw an error. Then admin homepage will not show anything.

3. For those contributors don't have cached pull request, we should validate not only the repo pull request but also validate to shared gist repos/orgs accordingly.

Small features:
1. Add config settings to allow only need the submitter to sign instead of all the committers of a pull request.

2. When user change name, we should also identify their previous signature.