### PR TITLE
Some small fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1501,6 +1501,11 @@
                 "domelementtype": "1.3.0"
             }
         },
+        "dont-sniff-mimetype": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dont-sniff-mimetype/-/dont-sniff-mimetype-1.0.0.tgz",
+            "integrity": "sha1-WTKJDcn04vGeXrAqIAJuXl78j1g="
+        },
         "dot-prop": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "colors": "^1.1.2",
         "connect-mongo": "^2.0.0",
         "cookie-parser": "^1.4.3",
+        "dont-sniff-mimetype": "^1.0.0",
         "ejs": "^2.5.7",
         "express": "^4.16.2",
         "express-session": "^1.15.6",

--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -120,6 +120,7 @@ function validatePullRequest(args, done) {
 
             return done();
         }
+        args.token = item.token;
         if (!item.gist) {
             return status.updateForNullCla(args, function () {
                 prService.deleteComment({

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -9,6 +9,7 @@ let path = require('path');
 let sass_middleware = require('node-sass-middleware');
 let cleanup = require('./middleware/cleanup');
 let noSniff = require('dont-sniff-mimetype');
+let mongoose = require('mongoose');
 // var sass_middleware = require('node-sass-middleware');
 
 // ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -140,12 +141,10 @@ async.series([
     // ////////////////////////////////////////////////////////////////////////////////////////////
 
     function (callback) {
-        let mongoose = require('mongoose');
-
-        mongoose.connect(config.server.mongodb.uri, {
+        retryInitializeMongoose(config.server.mongodb.uri, {
             useMongoClient: true,
             keepAlive: true
-        }, function () {
+        }, () => {
             bootstrap('documents', callback);
         });
 
@@ -233,5 +232,20 @@ app.all('/github/webhook/:repo', function (req, res) {
         res.status(500).send('Internal Server Error');
     }
 });
+
+function retryInitializeMongoose(uri, options, callback) {
+    const defaultInterval = 1000;
+    mongoose.connect(uri, options, err => {
+        if (err) {
+            console.log(err, `Retry initialize mongoose in ${options.retryInitializeInterval || defaultInterval} milliseconds`);
+            setTimeout(() => {
+                retryInitializeMongoose(uri, options);
+            }, options.retryInitializeInterval || defaultInterval);
+        }
+        if (typeof callback === 'function') {
+            callback();
+        }
+    });
+}
 
 module.exports = app;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -8,6 +8,7 @@ let passport = require('passport');
 let path = require('path');
 let sass_middleware = require('node-sass-middleware');
 let cleanup = require('./middleware/cleanup');
+let noSniff = require('dont-sniff-mimetype');
 // var sass_middleware = require('node-sass-middleware');
 
 // ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -41,6 +42,7 @@ app.use(function (req, res, next) {
 app.use(require('x-frame-options')());
 app.use(require('body-parser').json({ limit: '5mb' }));
 app.use(require('cookie-parser')());
+app.use(noSniff());
 let expressSession = require('express-session');
 let MongoStore = require('connect-mongo')(expressSession);
 


### PR DESCRIPTION
1. Add no-sniff MIME type protection.
2. When contributor clicks link to recheck pull request, we should use the stored admin token to update status and comments.
3. When using hibernates, the container instance may be created without network initiated. Because mongoose will not reconnect if the first connection failed. The whole app is not working properly. Add retry function to reconnect MongoDB when the first connection failed.
