### PR TITLE
Docker container fails to start with alpine:3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.7
 MAINTAINER GoCD Contributors <go-cd-dev@googlegroups.com>
 
 EXPOSE 5000


### PR DESCRIPTION
The docker container won't start with version 3.5 of the alpine base container. I tested it with version 3.7 and it built fine.