### PR TITLE
Allow specifying a custom login page template.

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -80,6 +80,10 @@ module.exports = {
             channel: process.env.SLACK_CHANNEL
         },
 
+        templates: {
+            login: process.env.LOGIN_PAGE_TEMPLATE || path.join(__dirname, 'client', 'login.html')
+        },
+
         sentry_dsn: process.env.SENTRY_DSN,
 
         api_access: {

--- a/src/server/controller/default.js
+++ b/src/server/controller/default.js
@@ -50,7 +50,7 @@ router.all('/static/*', function (req, res) {
     if (req.user && req.path === '/static/cla-assistant.json') {
         filePath = path.join(__dirname, '..', '..', '..', 'cla-assistant.json');
     } else {
-        filePath = path.join(__dirname, '..', '..', 'client', 'login.html');
+        filePath = config.server.templates.login;
     }
     res.setHeader('Last-Modified', (new Date()).toUTCString());
     res.status(200).sendFile(filePath);
@@ -73,7 +73,7 @@ router.all('/*', function (req, res) {
     if ((req.user && req.user.scope && req.user.scope.indexOf('write:repo_hook') > -1) || req.path !== '/') {
         filePath = path.join(__dirname, '..', '..', 'client', 'home.html');
     } else {
-        filePath = path.join(__dirname, '..', '..', 'client', 'login.html');
+        filePath = config.server.templates.login;
     }
     res.setHeader('Last-Modified', (new Date()).toUTCString());
     res.status(200).sendFile(filePath);


### PR DESCRIPTION
It would be useful to be able to override the template used for the login page without modifying the source code of cla-assistant itself.

This pull request allows specifying the location of the template used for the login page in an environment variable so that an alternative login page can be used whilst leaving the installation of CLA assistant pristine.

Closes #363.