### PR TITLE
improve handling of noscript (related to #349)

### DIFF
--- a/src/client/app.js
+++ b/src/client/app.js
@@ -17,6 +17,7 @@ var filters = angular.module('cla.filters', []);
 
 angular.element(document).ready(function () {
     angular.bootstrap(document, ['app']);
+    angular.element(document.querySelectorAll('.needs-javascript')).removeClass('needs-javascript');
 });
 
 // *************************************************************

--- a/src/client/assets/styles/app.scss
+++ b/src/client/assets/styles/app.scss
@@ -598,3 +598,7 @@ a.anchor .octicon-link {
   font-size: smaller;
   display: inline-block;
 }
+
+.needs-javascript {
+  display: none;
+}

--- a/src/client/home.html
+++ b/src/client/home.html
@@ -44,9 +44,11 @@
             <div class="navbar-home-left">
                 <div ng-show="!!user.value.login">
                     <a ng-href="{{user.value.html_url}}" target="spcae">
-                        <img ng-src="{{ user.value.avatarUrl }}" style="height:25px;" />
+                        <img class="needs-javascript" alt="[ {{ user.value.login }} avatar ]" ng-src="{{ user.value.avatarUrl }}" style="height:25px;" />
                         <a class="navbar-text-hide">&nbsp; Hey,
-                            <b>{{ user.value.login }}</b>!</a>
+                            <noscript>GitHub user whose browser isn't processing JavaScript</noscript>
+                            <b class="needs-javascript">{{ user.value.login }}</b>!
+                        </a>
                     </a>
                 </div>
             </div>
@@ -56,7 +58,7 @@
             </div>
             <div class="navbar-center">
                 <a href="/">
-                    <img class="center-block img-responsive" src="/assets/images/logo_b.svg" style="width:55px;">
+                    <img class="center-block img-responsive" src="/assets/images/logo_b.svg" alt="[ CLA - assistant ]" style="width:55px;">
                 </a>
             </div>
         </div>


### PR DESCRIPTION
This is a rough attempt at improving the behavior of cla-assistant as seen by browsers that render `<noscript>`

Currently the rendering looks like this:
![image](https://user-images.githubusercontent.com/2119212/51889732-4bfdb580-2368-11e9-9549-b334a935171f.png)

![image](https://user-images.githubusercontent.com/2119212/51889711-3a1c1280-2368-11e9-86f1-55af6e07425d.png)

(That the username disappears long before the brand logo is a little odd, but we can cross the mobile bridge later.)