### PR TITLE
Check HEAD branch organization user

### DIFF
--- a/src/client/modals/editLinkedItem.js
+++ b/src/client/modals/editLinkedItem.js
@@ -24,6 +24,15 @@ module.controller('EditLinkedItemCtrl', function ($scope, $modalInstance, $windo
             windowClass: 'howto'
         });
     };
+
+    $scope.whitelistInfo = function () {
+        $modal.open({
+            templateUrl: '/modals/templates/whitelist_info.html',
+            controller: 'InfoCtrl',
+            windowClass: 'howto'
+        });
+    };
+
     $scope.ok = function () {
         $scope.selected.item.gist = $scope.selected.gist.url;
         linkItemService.updateLink($scope.selected.item).then(function success(data) {

--- a/src/client/modals/templates/editLinkedItem.html
+++ b/src/client/modals/templates/editLinkedItem.html
@@ -69,7 +69,8 @@
     <div class="row">
         <div class="col-xs-12">
             <div class="form-group">
-                <div style="margin-bottom: 5px; margin-top: 5px;">Provide user names, who doesn't need to sign the CLA
+                <div style="margin-bottom: 5px; margin-top: 5px;">Specify usernames to be whitelisted
+                    <span class="clickable" ng-click="whitelistInfo()" style="font-size:12px; text-decoration:underline">(how does this work?)</span>
                     <br/>
                     <span class="side-note">(you can also use wildcard
                         <span class="wildcard">*</span>)</span>

--- a/src/client/modals/templates/whitelist_info.html
+++ b/src/client/modals/templates/whitelist_info.html
@@ -1,11 +1,41 @@
 <div class="modal-body modal-primary">
-    <div ng-click="cancel()" class="fa fa-times close-button"></div>
+  <div ng-click="cancel()" class="fa fa-times close-button"></div>
 
-    <div class="free-space">
-        <h4>How does whitelisting work?</h4>
-        <div>
-                If a GitHub username is included in the whitelist, they will not be required to sign a CLA. This also applies to organization usernames.
-        </div>
+  <div class="free-space">
+    <h4>How does whitelisting work?</h4>
+    <div>
+      If a GitHub username is included in the whitelist, they will not be
+      required to sign a CLA. This also applies to organization usernames.
     </div>
-
+    <h4>Why whitelist usernames?</h4>
+    <div>
+      Since there's no way for bot users (such as Dependabot or Greenkeeper) to
+      sign a CLA, you may want to whitelist them. You can do so by adding their
+      names (in this case <i>dependabot[bot]</i> and
+      <i>greenkeeper[bot]</i> separated by a comma) to the whitelist. You can
+      also use wildcard symbol in case you want to whitelist all bot users
+      <i>*[bot]</i>.
+    </div>
+    <h4>Why whitelist organizations?</h4>
+    <div>
+      We see at least two use cases you may want to do so:
+      <ul>
+        <li>
+          You develop in a team and commit your changes via feature branches. As
+          soon you create a new pull request CLA assistant would ask you and
+          your team fellows to sign a CLA even if you are part of the
+          organization and doesn't need to do so. Now if you whitelist your own
+          organization name all pull requests coming from the same repository
+          will pass the CLA check.
+        </li>
+        <li>
+          You get contributions from another company which has already signed
+          your corporate CLA. You may want to let CLA assistant accept all PRs
+          coming from this company. Now you can whitelist the GitHub
+          organization name of this company and all pull requests coming from
+          this GitHub organization (i.e., from that organization's fork) will pass the check.
+        </li>
+      </ul>
+    </div>
+  </div>
 </div>

--- a/src/client/modals/templates/whitelist_info.html
+++ b/src/client/modals/templates/whitelist_info.html
@@ -1,0 +1,11 @@
+<div class="modal-body modal-primary">
+    <div ng-click="cancel()" class="fa fa-times close-button"></div>
+
+    <div class="free-space">
+        <h4>How does whitelisting work?</h4>
+        <div>
+                If a GitHub username is included in the whitelist, they will not be required to sign a CLA. This also applies to organization usernames.
+        </div>
+    </div>
+
+</div>

--- a/src/config.js
+++ b/src/config.js
@@ -104,6 +104,7 @@ module.exports = {
 
         feature_flag: {
             required_signees: process.env.REQUIRED_SIGNEES || '',
+            organization_override_enabled: process.env.ORG_OVERRIDE_ENABLED || false,
         },
 
         static: [

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -438,7 +438,9 @@ module.exports = function () {
             args.orgId = item.orgId;
             args.onDates = [new Date()];
 
-            if (!args.gist) return ({ signed: true });
+            if (!args.gist) { 
+                return ({ signed: true });
+            }
 
             const gist = await getGistObject(args.gist, item.token);
             if (!gist) {

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -500,7 +500,7 @@ describe('', function () {
             sinon.assert.calledWithMatch(cla.sign, expArgs.claSign);
         });
 
-        it('should update status of all open pull requests for the repo if user model has no requests stored', async function () {
+        xit('should update status of all open pull requests for the repo if user model has no requests stored', async function () {
             testUser.requests = undefined;
 
             const res = await cla_api.sign(req);

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -500,19 +500,28 @@ describe('', function () {
             sinon.assert.calledWithMatch(cla.sign, expArgs.claSign);
         });
 
-        xit('should update status of all open pull requests for the repo if user model has no requests stored', async function () {
+        it('should update status of all open pull requests for the repo if user model has no requests stored', async function () {
             testUser.requests = undefined;
+            this.timeout(100);
+            try {
+                const res = await cla_api.sign(req);
 
-            const res = await cla_api.sign(req);
-
-            assert.ok(res);
-            sinon.assert.calledWithMatch(cla.sign, expArgs.claSign);
-            assert(github.call.calledWithMatch({
-                obj: 'pullRequests',
-                fun: 'getAll'
-            }));
-            assert(prService.editComment.called);
-            assert.equal(statusService.update.callCount, 2);
+                return new Promise((resolve) => {
+                    setTimeout(function () {
+                        assert.ok(res);
+                        sinon.assert.calledWithMatch(cla.sign, expArgs.claSign);
+                        assert(github.call.calledWithMatch({
+                            obj: 'pullRequests',
+                            fun: 'getAll'
+                        }));
+                        assert(prService.editComment.called);
+                        assert.equal(statusService.update.callCount, 2);
+                        resolve();
+                    }, 50);
+                });
+            } catch (e) {
+                assert.ifError(e);
+            }
         });
 
         it('should update status of all open pull requests for the repos and orgs that shared the same gist if user model has no requests stored', async function () {


### PR DESCRIPTION
_This PR adds functionality that was previously discussed with @KharitonOff._

## Changes

+ Add optional feature flag: `organization_override_enabled`
+ With feature flag `true`, the PR webhook flow will now check to see whether the "Organization" user that is tied to the HEAD repo's branch is whitelisted (the whitelist being an existing functionality)

**N.B.: The `checkPullRequestSignatures` method has been updated to use Promises/(async/await).** This was necessary to avoid a rather messy change that would otherwise be required if the mix of Promise chains and callbacks were continued to be used. Without this, the code would've otherwise required some nasty nested Promise chains and/or duplicate calls to the `getPR` method. While I don't really like having to do so much refactoring to add this bit of functionality, I couldn't find a good way to make it work otherwise (and without breaking a bunch of tests). If these changes are not acceptable, I can try to find a different way, but the outcome may be worse overall.