### PR TITLE
Rename avatarUrl to avatar_url for users call

### DIFF
--- a/src/client/home.html
+++ b/src/client/home.html
@@ -44,7 +44,7 @@
             <div class="navbar-home-left">
                 <div ng-show="!!user.value.login">
                     <a ng-href="{{user.value.html_url}}" target="space">
-                        <img class="needs-javascript" alt="[ {{ user.value.login }} avatar ]" ng-src="{{ user.value.avatarUrl }}" style="height:25px;" />
+                        <img class="needs-javascript" alt="[ {{ user.value.login }} avatar ]" ng-src="{{ user.value.avatar_url }}" style="height:25px;" />
                         <a class="navbar-text-hide">&nbsp; Hey,
                             <noscript>GitHub user whose browser isn't processing JavaScript</noscript>
                             <b class="needs-javascript">{{ user.value.login }}</b>!

--- a/src/client/templates/my-cla.html
+++ b/src/client/templates/my-cla.html
@@ -5,7 +5,7 @@
         <div class="navbar-header navbar-home-left navbar-home-text" style="margin-left: 0px">
             <div ng-show="!!user.value.login">
                 <a ng-href="{{user.value.html_url}}" target="space">
-                    <img ng-src="{{ user.value.avatarUrl }}" style="height:25px;" />
+                    <img ng-src="{{ user.value.avatar_url }}" style="height:25px;" />
                     <a class="navbar-text-hide">&nbsp; Hey,
                         <b>{{ user.value.login }}</b>!</a>
                 </a>

--- a/src/tests/client/controller/HomeCtrl.spec.js
+++ b/src/tests/client/controller/HomeCtrl.spec.js
@@ -9,7 +9,7 @@ describe('Home Controller', function () {
         'owner': {
             'login': 'octocat',
             'id': 1,
-            'avatarUrl': 'https://github.com/images/error/octocat_happy.gif',
+            'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
             'gravatar_id': '',
             'url': 'https://api.github.com/users/octocat',
             'html_url': 'https://github.com/octocat',
@@ -69,7 +69,7 @@ describe('Home Controller', function () {
         'owner': {
             'login': 'octocat',
             'id': 1,
-            'avatarUrl': 'https://github.com/images/error/octocat_happy.gif',
+            'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
             'gravatar_id': '',
             'url': 'https://api.github.com/users/octocat',
             'html_url': 'https://github.com/octocat',


### PR DESCRIPTION
GraphQL calls return `avatarUrl`. However to get user's data the server uses `api/github/call`, which returns `avatar_url`.