### PR TITLE
Updating some URLs to the https:// prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ An issue that is about a real bug is closed as soon as the fix is committed.
 ### Reporting Security Issues
 
 If you find a security issue, please act responsibly and report it not in the public issue tracker, but directly to us, so we can fix it before it can be exploited.
-Please send the related information to secure@sap.com using [PGP for e-mail encryption](http://global.sap.com/pc/security/keyblock.txt).
+Please send the related information to secure@sap.com using [PGP for e-mail encryption](https://global.sap.com/pc/security/keyblock.txt).
 Also refer to the general [SAP security information page](https://www.sap.com/corporate/en/company/security.html).
 
 
@@ -81,14 +81,14 @@ You are welcome to contribute code to CLA Assistant in order to fix bugs or to i
 
 There are three important things to know:
 
-1.  You must be aware of the Apache License (which describes contributions) and **agree to the Contributors License Agreement**. This is common practice in all major Open Source projects. 
+1.  You must be aware of the Apache License (which describes contributions) and **agree to the Contributors License Agreement**. This is common practice in all major Open Source projects.
  For company contributors special rules apply. See the respective section below for details.
 2.  There are **several requirements regarding code style, quality, and product standards** which need to be met (we also have to follow them). The respective section below gives more details on the coding guidelines.
 3.  **Not all proposed contributions can be accepted**. Some features may e.g. just fit a third-party add-on better. The code must fit the overall direction of CLA Assistant and really improve it. The more effort you invest, the better you should clarify in advance whether the contribution fits: the best way would be to just open an issue to discuss the feature you plan to implement (make it clear you intend to contribute).
 
 ### Contributor License Agreement
 
-When you contribute (code, documentation, or anything else), you have to be aware that your contribution is covered by the same [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0) that is applied to CLA Assistant itself.
+When you contribute (code, documentation, or anything else), you have to be aware that your contribution is covered by the same [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0) that is applied to CLA Assistant itself.
 In particular you need to agree to the Individual Contributor License Agreement,
 which can be [found here](https://gist.github.com/CLAassistant/bd1ea8ec8aa0357414e8).
 (This applies to all contributors, including those contributing on behalf of a company). If you agree to its content, you simply have to click on the link posted by the CLA assistant as a comment to the pull request. Click it to check the CLA, then accept it on the following screen if you agree to it. CLA assistant will save this decision for upcoming contributions and will notify you if there is any change to the CLA in the meantime.
@@ -123,7 +123,7 @@ These are some of the rules we try to follow:
 1.  Make sure the change would be welcome (e.g. a bugfix or a useful feature); best do so by proposing it in a GitHub issue
 2.  Create a branch forking the cla-assistant repository and do your change
 3.  Commit and push your changes on that branch
-4.  In the commit message 
+4.  In the commit message
  - Describe the problem you fix with this change.
  - Describe the effect that this change has from a user's point of view. App crashes and lockups are pretty convincing for example, but not all bugs are that obvious and should be mentioned in the text.
  - Describe the technical details of what you changed. It is important to describe the change in a most understandable way so the reviewer is able to verify that the code is behaving as you intend it to.

--- a/src/client/modals/templates/info_gist.html
+++ b/src/client/modals/templates/info_gist.html
@@ -4,7 +4,7 @@
     <div class="free-space">
         <h4>How can I create a CLA Gist?</h4>
         <div>
-        		At <a href="http://gist.github.com" target="_blank" class="text-primary">gist.github.com</a> enter a file name and paste the content of your CLA.
+        		At <a href="https://gist.github.com" target="_blank" class="text-primary">gist.github.com</a> enter a file name and paste the content of your CLA.
         </div>
     </div>
 


### PR DESCRIPTION
While some of the http:// links within the CLA Assistant source
base are served from hosts that may not support SSL, our scanners
have suggested these specific fixes to help make the web a little
more secure.

And keep our corporate management happy...

Specific links:
- To the main Gist homepage
- To the SAP PGP key
- To the Apache 2.0 License

My editor also trimed a few spaces at the end of lines. If this is an issue, let me know, and I will fix it.