### PR TITLE
Have the main table take up entire width of screen

### DIFF
--- a/src/client/home.html
+++ b/src/client/home.html
@@ -66,7 +66,7 @@
 
     <div class="container-fluid ui-view-content">
         <div style="margin-left:15px; margin-right: 15px">
-            <section ui-view class="col-md-8 col-md-offset-2"></section>
+            <section ui-view class="col-md-12"></section>
         </div>
     </div>
 


### PR DESCRIPTION
- set the class name to be 'col-md-12' instead of 'col-md-8' with offset.
- Fixes #452

**Before**

<img width="1668" alt="Screen Shot 2019-07-15 at 11 23 11 AM" src="https://user-images.githubusercontent.com/1271364/61196216-02750d00-a6f3-11e9-8da2-a03edf535619.png">

**After**

![Screen Shot 2019-07-15 at 11 19 25 AM](https://user-images.githubusercontent.com/1271364/61196156-a6aa8400-a6f2-11e9-8a1e-4af952ea3042.png)
