### PR TITLE
Store full response in cache instead of custom built response object

### DIFF
--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -23,10 +23,7 @@ async function callGithub(octokit, obj, fun, arg, cacheKey) {
     }
 
     if (res && config.server.cache_time > 0) {
-        cache.put(cacheKey, {
-            data: res,
-            headers: res && res.headers ? res.headers : undefined
-        }, 60000 * config.server.cache_time)
+        cache.put(cacheKey, res, 60000 * config.server.cache_time)
     }
 
     return res


### PR DESCRIPTION
In the upgrade from Github 13.1.1 to Octokit 16.18.1, a regression was introduced when responses are returned from the cache in https://github.com/cla-assistant/cla-assistant/commit/b61cba55429a0eaaca03b6b18f1755b09db59f42#diff-2b2595aac333a35247dfc324a84eb20b.

When saved to the cache, the original response is custom built and full response is stored under a new `data` key ([source](https://github.com/cla-assistant/cla-assistant/blob/master/src/server/services/github.js#L27)). Therefore any calls into that returned cache object ([example](https://github.com/cla-assistant/cla-assistant/blob/master/src/server/services/cla.js#L236)) don't have the same data structure as a fresh API call and therefore fail with errors like `Cannot read property 'id' of undefined`.

The original response looks like:
````js
{ status: 200,
  url: 'https://api.github.com/repos/cla-assistant/cla-assistant',
  headers: { ... },
  data: 
    { owner: 
      { id: 26210598,
        ... }
      ... },
}
````

But responses from the cache look like:
````js
{ data:
   { status: 200,
     url: 'https://api.github.com/repos/cla-assistant/cla-assistant',
     headers: { ... },
     data: 
       { owner: 
         { id: 26210598,
           ... }
         ... },
   },
  headers: { ... }
}
````

This change simply modifies the cache payload to be the full response rather than a custom built response body. Then any method that returns an object from the cache can utilize it as if it was a fresh response from the GitHub API. 