### PR TITLE
Add build task so Heroku can build the Javascript bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
         "node": "12.6"
     },
     "scripts": {
+        "build": "node_modules/grunt/bin/grunt build",
         "start": "node app.js",
         "postinstall": "bower install",
         "test": "node_modules/grunt/bin/grunt test",


### PR DESCRIPTION
Heroku requires a `build` task in order to build the Javascript bundle, see https://devcenter.heroku.com/articles/node-with-grunt#specify-your-grunt-task-in-a-build-script for details.

This change adds a simple task to package.json so the app can be built.