### PR TITLE
Reword run-on sentence in CLA signing request

### DIFF
--- a/src/server/services/pullRequest.js
+++ b/src/server/services/pullRequest.js
@@ -13,7 +13,7 @@ const commentText = (signed, badgeUrl, claUrl, userMap, recheckUrl) => {
     }
 
     let youAll = (committersCount > 1 ? 'you all' : 'you')
-    let text = `[![CLA assistant check](${badgeUrl})](${claUrl}) <br/>Thank you for your submission, we really appreciate it. Like many open source projects, we ask that ${youAll} sign our [Contributor License Agreement](${claUrl}) before we can accept your contribution.<br/>`
+    let text = `[![CLA assistant check](${badgeUrl})](${claUrl}) <br/>Thank you for your submission! We really appreciate it. Like many open source projects, we ask that ${youAll} sign our [Contributor License Agreement](${claUrl}) before we can accept your contribution.<br/>`
     if (committersCount > 1) {
         text += '**' + userMap.signed.length + '** out of **' + (userMap.signed.length + userMap.not_signed.length) + '** committers have signed the CLA.<br/>'
         userMap.signed.forEach(function (signee) {


### PR DESCRIPTION
👋 hey team, thanks for making such a useful + free GitHub plugin. There is just one tiny gripe I have, which is that the initial CLA signing request for a new contributor leads with a run-on sentence. Totally realize that I might be the only person in the world bothered by this, but bother me it does, so figured I'd throw up a PR and see what y'all think.

----

This sentence is a new contributor's first experience with CLA
assistant and was slightly ungrammatical.