### PR TITLE
Fix race for out-of-order webhooks.

### DIFF
--- a/src/server/webhooks/ping.js
+++ b/src/server/webhooks/ping.js
@@ -2,6 +2,11 @@
 // GitHub Ping Webhook Handler
 //////////////////////////////////////////////////////////////////////////////////////////////
 
-module.exports = function (req, res) {
-    res.status(200).send('OK');
-};
+module.exports = {
+    accepts: function () {
+        return true
+    },
+    handle: function (req, res) {
+        res.status(200).send('OK');
+    }
+}

--- a/src/server/webhooks/pull_request.js
+++ b/src/server/webhooks/pull_request.js
@@ -130,9 +130,11 @@ async function handleWebHook(args, item) {
     }
 }
 
-module.exports = async function (req, res) {
-
-    if (['opened', 'reopened', 'synchronize'].indexOf(req.args.action) > -1 && (req.args.repository && req.args.repository.private == false)) {
+module.exports = {
+    accepts: function (req) {
+        return ['opened', 'reopened', 'synchronize'].indexOf(req.args.action) > -1 && (req.args.repository && req.args.repository.private == false)
+    },
+    handle: async function (req, res) {
         const args = {
             owner: req.args.repository.owner.login,
             repoId: req.args.repository.id,
@@ -158,6 +160,6 @@ module.exports = async function (req, res) {
         } catch (e) {
             logger.warn(e)
         }
+        res.status(200).send('OK')
     }
-    res.status(200).send('OK')
 }

--- a/src/tests/server/webhooks/pull_request.js
+++ b/src/tests/server/webhooks/pull_request.js
@@ -16,7 +16,13 @@ const config = require('../../../config')
 const User = require('../../../server/documents/user').User
 
 // webhook under test
-const pull_request = require('../../../server/webhooks/pull_request')
+const webhook = require('../../../server/webhooks/pull_request')
+
+function pull_request(req, res) {
+    if (webhook.accepts(req)) {
+        return webhook.handle(req, res)
+    }
+}
 
 const testData = {
     'id': 1,


### PR DESCRIPTION
It is possible that the `opened` action may not be the first webhook actually
received for a PR. If this should occur, users would see the CLA check for a PR
appear to hang until a new commit is pushed to the PR.

This change breaks the filtering and handling of a request into two
separately-exported functions, `accepts` and `handle`. Only acceptable
requests will be enqueued for debouncing. As a convenience to operators, the
no-op case will result in a 204 response code. I have confirmed that GitHub
treats a 204 as a successful response code in a private instance of CLA
checker.

Fixes #545