### PR TITLE
Remove usage of the word “whitelist”

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To get started, simply store your CLA as a GitHub Gist file then link it with th
 
 Repository owners can review a list of users who signed the CLA for each version of it. To get started, visit https://cla-assistant.io.
 
-We also developed a [lite version](https://github.com/cla-assistant/github-action) of CLA Assistant using GitHub Actions which is in Alpha. You can checkout it out [here](https://github.com/cla-assistant/github-action). 
+We also developed a [lite version](https://github.com/cla-assistant/github-action) of CLA Assistant using GitHub Actions which is in Alpha. You can checkout it out [here](https://github.com/cla-assistant/github-action).
 
 Try
 ====
@@ -105,8 +105,8 @@ In case of problems or any further questions, please check our [general trouble 
 #### How can I contribute?
 You want to contribute to CLA Assistant? Welcome! Please read [here](https://github.com/cla-assistant/cla-assistant/blob/master/CONTRIBUTING.md).
 
-#### Can I whitelist bot users?
-Since there's no way for bot users (such as Dependabot or Greenkeeper) to sign a CLA, you may want to whitelist them. You can do so by importing their names (in this case `dependabot[bot]` and `greenkeeper[bot]`) in the CLA assistant dashboard.
+#### Can I allow bot user contributions?
+Since there's no way for bot users (such as Dependabot or Greenkeeper) to sign a CLA, you may want to allow their contributions without it. You can do so by importing their names (in this case `dependabot[bot]` and `greenkeeper[bot]`) in the CLA assistant dashboard.
 
 Setup your own instance of CLA assistant
 ==============================

--- a/src/client/controller/home.js
+++ b/src/client/controller/home.js
@@ -406,7 +406,7 @@ module.controller('HomeCtrl', ['$rootScope', '$scope', '$RPCService', '$RAW', '$
                 minFileChanges: $scope.selected.minFileChanges,
                 minCodeChanges: $scope.selected.minCodeChanges,
                 excludePattern: $scope.selected.item.excludePattern,
-                whiteListPattern: $scope.selected.whiteListPattern
+                allowListPattern: $scope.selected.allowListPattern
             };
             var promise = linkItemService.createLink($scope.selected.item, options);
 

--- a/src/client/modals/editLinkedItem.js
+++ b/src/client/modals/editLinkedItem.js
@@ -37,9 +37,9 @@ module.controller('EditLinkedItemCtrl', function ($scope, $modalInstance, $windo
         });
     };
 
-    $scope.whitelistInfo = function () {
+    $scope.allowlistInfo = function () {
         $modal.open({
-            templateUrl: '/modals/templates/whitelist_info.html',
+            templateUrl: '/modals/templates/allowlist_info.html',
             controller: 'InfoCtrl',
             windowClass: 'howto'
         });

--- a/src/client/modals/templates/allowlist_info.html
+++ b/src/client/modals/templates/allowlist_info.html
@@ -2,36 +2,36 @@
     <div ng-click="cancel()" class="fa fa-times close-button"></div>
 
     <div class="free-space">
-        <h4>How does whitelisting work?</h4>
+        <h4>How does always allowing users work?</h4>
         <div>
-            If a GitHub username is included in the whitelist, they will not be
+            If a GitHub username is included in the list to be always allowed, they will not be
             required to sign a CLA. This also applies to organization usernames.
         </div>
-        <h4>Why whitelist usernames?</h4>
+        <h4>Why always allowing usernames?</h4>
         <div>
             Since there's no way for bot users (such as Dependabot or Greenkeeper) to
-            sign a CLA, you may want to whitelist them. You can do so by adding their
-            names (in this case <i>dependabot-preview[bot]</i> and
-            <i>greenkeeper[bot]</i> separated by a comma) to the whitelist. You can
-            also use wildcard symbol in case you want to whitelist all bot users
-            <i>*[bot]</i>.
+            sign a CLA, you may want to allow their contributions without it. You can
+            do so by adding their names (in this case
+            <i>dependabot-preview[bot]</i> and <i>greenkeeper[bot]</i> separated by a
+            comma) to the list of always allowed users. You can also use wildcard
+            symbol in case you want to allow all bot users <i>*[bot]</i>.
         </div>
-        <h4>Why whitelist organizations?</h4>
+        <h4>Why always allow whole organizations?</h4>
         <div>
             We see at least two use cases you may want to do so:
             <ul>
                 <li>
                     You develop in a team and commit your changes via feature branches. As
-                    soon you create a new pull request CLA assistant would ask you and
+                    soon as you create a new pull request CLA assistant would ask you and
                     your team fellows to sign a CLA even if you are part of the
-                    organization and doesn't need to do so. Now if you whitelist your own
-                    organization name all pull requests coming from the same repository
-                    will pass the CLA check.
+                    organization and doesn't need to do so. Now if you always allow your
+                    own organization name all pull requests coming from the same
+                    repository will pass the CLA check.
                 </li>
                 <li>
                     You get contributions from another company which has already signed
                     your corporate CLA. You may want to let CLA assistant accept all PRs
-                    coming from this company. Now you can whitelist the GitHub
+                    coming from this company. Now you can always allow the GitHub
                     organization name of this company and all pull requests coming from
                     this GitHub organization (i.e., from that organization's fork) will pass the check.
                 </li>

--- a/src/client/modals/templates/editLinkedItem.html
+++ b/src/client/modals/templates/editLinkedItem.html
@@ -76,14 +76,14 @@
     <div class="row">
         <div class="col-xs-12">
             <div class="form-group">
-                <div style="margin-bottom: 5px; margin-top: 5px;">Specify usernames to be whitelisted
-                    <span class="clickable" ng-click="whitelistInfo()"
+                <div style="margin-bottom: 5px; margin-top: 5px;">Specify usernames to be always allowed
+                    <span class="clickable" ng-click="allowlistInfo()"
                         style="font-size:12px; text-decoration:underline">(how does this work?)</span>
                     <br />
                     <span class="side-note">(you can also use wildcard
                         <span class="wildcard">*</span>)</span>
                 </div>
-                <input id="whiteListPattern" class="form-control" ng-model="selected.item.whiteListPattern"
+                <input id="allowListPattern" class="form-control" ng-model="selected.item.allowListPattern"
                     placeholder="user1,user2,*[bot]"></input>
             </div>
         </div>

--- a/src/client/services/linkItem.js
+++ b/src/client/services/linkItem.js
@@ -10,7 +10,7 @@ module.factory('linkItemService', ['$RPCService',
             var newItem = {
                 gist: options.gist.url,
                 sharedGist: options.sharedGist,
-                whiteListPattern: options.whiteListPattern,
+                allowListPattern: options.allowListPattern,
                 minFileChanges: options.minFileChanges,
                 minCodeChanges: options.minCodeChanges,
                 privacyPolicy: options.privacyPolicy

--- a/src/server/api/org.js
+++ b/src/server/api/org.js
@@ -16,7 +16,7 @@ const newOrgSchema = Joi.object().keys({
     sharedGist: Joi.boolean(),
     minFileChanges: Joi.number(),
     minCodeChanges: Joi.number(),
-    whiteListPattern: Joi.string().allow(''),
+    allowListPattern: Joi.string().allow(''),
     privacyPolicy: Joi.string().allow('')
 })
 const removeOrgSchema = Joi.object().keys({

--- a/src/server/api/repo.js
+++ b/src/server/api/repo.js
@@ -14,7 +14,7 @@ const REPOCREATESCHEMA = Joi.object().keys({
     sharedGist: Joi.boolean(),
     minFileChanges: Joi.number(),
     minCodeChanges: Joi.number(),
-    whiteListPattern: Joi.string().allow(''),
+    allowListPattern: Joi.string().allow(''),
     privacyPolicy: Joi.string().allow('')
 })
 

--- a/src/server/documents/org.js
+++ b/src/server/documents/org.js
@@ -10,7 +10,7 @@ const OrgSchema = mongoose.Schema({
     sharedGist: Boolean,
     minFileChanges: Number,
     minCodeChanges: Number,
-    whiteListPattern: String,
+    allowListPattern: String,
     privacyPolicy: String,
     updated_at: Date
 })
@@ -19,8 +19,8 @@ OrgSchema.methods.isRepoExcluded = function (repo) {
     return utils.checkPattern(this.excludePattern, repo)
 }
 
-OrgSchema.methods.isUserWhitelisted = function (user) {
-    return utils.checkPatternWildcard(this.whiteListPattern, user)
+OrgSchema.methods.isUserOnAllowlist = function (user) {
+    return utils.checkPatternWildcard(this.allowListPattern, user)
 }
 
 OrgSchema.index({

--- a/src/server/documents/repo.js
+++ b/src/server/documents/repo.js
@@ -11,7 +11,7 @@ const RepoSchema = mongoose.Schema({
     sharedGist: Boolean,
     minFileChanges: Number,
     minCodeChanges: Number,
-    whiteListPattern: String,
+    allowListPattern: String,
     privacyPolicy: String,
     updated_at: Date
 })
@@ -25,8 +25,8 @@ const indexOptions = {
     unique: true
 }
 
-RepoSchema.methods.isUserWhitelisted = function (user) {
-    return utils.checkPatternWildcard(this.whiteListPattern, user)
+RepoSchema.methods.isUserOnAllowlist = function (user) {
+    return utils.checkPatternWildcard(this.allowListPattern, user)
 }
 
 const Repo = mongoose.model('Repo', RepoSchema)

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -426,7 +426,7 @@ class ClaService {
                 const {
                     owner: baseOrg
                 } = pullRequest.base.repo
-                if (item.isUserWhitelisted !== undefined && item.isUserWhitelisted(headOrg.login)) {
+                if (item.isUserOnAllowlist !== undefined && item.isUserOnAllowlist(headOrg.login)) {
                     const orgMembers = await this._getGHOrgMembers(headOrg.login, item.token)
                     const committers = await repoService.getPRCommitters(args)
                     var externalCommitters = _.differenceBy(committers, orgMembers, 'id')
@@ -437,7 +437,7 @@ class ClaService {
 
                     } else if (externalCommitters.length > 0 && isForked && baseOrg.login !== headOrg.login) {
                         externalCommitters = externalCommitters.filter(externalCommitter =>
-                            externalCommitter && !(item.isUserWhitelisted !== undefined && item.isUserWhitelisted(externalCommitter.name))
+                            externalCommitter && !(item.isUserOnAllowlist !== undefined && item.isUserOnAllowlist(externalCommitter.name))
                         )
                         hasExternalCommiter.check = true
                         hasExternalCommiter.orgName = headOrg.login
@@ -493,7 +493,7 @@ class ClaService {
         }
 
         signees = signees.filter(signee =>
-            signee && !(item.isUserWhitelisted !== undefined && item.isUserWhitelisted(signee.name))
+            signee && !(item.isUserOnAllowlist !== undefined && item.isUserOnAllowlist(signee.name))
         )
         return this._checkAll(
             signees,

--- a/src/server/services/org.js
+++ b/src/server/services/org.js
@@ -19,7 +19,7 @@ class OrgService {
             sharedGist: !!args.sharedGist,
             minFileChanges: args.minFileChanges,
             minCodeChanges: args.minCodeChanges,
-            whiteListPattern: args.whiteListPattern,
+            allowListPattern: args.allowListPattern,
             privacyPolicy: args.privacyPolicy,
             updatedAt: new Date()
         })
@@ -37,7 +37,7 @@ class OrgService {
         org.excludePattern = args.excludePattern
         org.minFileChanges = args.minFileChanges
         org.minCodeChanges = args.minCodeChanges
-        org.whiteListPattern = args.whiteListPattern
+        org.allowListPattern = args.allowListPattern
         org.privacyPolicy = args.privacyPolicy
         org.updatedAt = new Date()
 

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -66,7 +66,7 @@ class RepoService {
             sharedGist: !!args.sharedGist,
             minFileChanges: args.minFileChanges,
             minCodeChanges: args.minCodeChanges,
-            whiteListPattern: args.whiteListPattern,
+            allowListPattern: args.allowListPattern,
             privacyPolicy: args.privacyPolicy,
             updatedAt: new Date()
         })
@@ -137,7 +137,7 @@ class RepoService {
         repo.sharedGist = !!args.sharedGist
         repo.minFileChanges = args.minFileChanges
         repo.minCodeChanges = args.minCodeChanges
-        repo.whiteListPattern = args.whiteListPattern
+        repo.allowListPattern = args.allowListPattern
         repo.privacyPolicy = args.privacyPolicy
         repo.updatedAt = new Date()
 

--- a/src/tests/acceptance_tests/allowlist_user_on_repo2.spec.js
+++ b/src/tests/acceptance_tests/allowlist_user_on_repo2.spec.js
@@ -17,7 +17,7 @@ Scenario(`link repo2`, (I) => {
     cla.linkRepo(I, testUserName, `repo2`)
 })
 
-Scenario(`Add whitelisted user for repo2`, (I) => {
+Scenario(`Add user on allowlist for repo2`, (I) => {
     I.amOnPage(`https://preview.cla-assistant.io/`)
     I.waitForVisible(`//button[contains(., "Configure CLA")]`, 5)
     I.waitForInvisible(`.loading-indicator`, 5)
@@ -28,13 +28,13 @@ Scenario(`Add whitelisted user for repo2`, (I) => {
     I.moveCursorTo(`//tr[contains(., "${testUserName} / repo2")]//i[contains(@class,"fa-ellipsis-h")]`)
     I.click(`//tr[contains(., "${testUserName} / repo2")]//i[contains(@class,"fa-ellipsis-h")]`)
     I.click(`Edit`)
-    I.waitForEnabled(`#whiteListPattern`, 2)
-    I.fillField(`#whiteListPattern`, testContributorName)
+    I.waitForEnabled(`#allowListPattern`, 2)
+    I.fillField(`#allowListPattern`, testContributorName)
     I.wait(2)
     I.waitForElement(`//button[contains(.,"Save")]`)
     I.moveCursorTo(`//button[contains(.,"Save")]`)
     I.click(`//button[contains(.,"Save")]`)
-    I.waitForInvisible(`#whiteListPattern`, 5)
+    I.waitForInvisible(`#allowListPattern`, 5)
 })
 
 Feature(`Pull Request`)

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -1193,7 +1193,7 @@ describe('', () => {
             }, 100))
         })
 
-        it('should update status with differentiation between whitelisted and other committers', async () => {
+        it('should update status with differentiation between people on allowlist and other committers', async () => {
             cla.check.restore()
             sinon.stub(cla, 'check').callsFake(async (args) => {
                 const res = {

--- a/src/tests/server/documents/org.js
+++ b/src/tests/server/documents/org.js
@@ -29,22 +29,22 @@ describe('org document', () => {
         assert.equal(org.isRepoExcluded('qux'), false)
     })
 
-    it('should properly parse whitelisted users', async () => {
+    it('should properly parse allowlist', async () => {
         const testOrg = testData.org_from_db_with_excluded_patterns
-        testOrg.whiteListPattern = 'login0,*1,*[bot]'
+        testOrg.allowListPattern = 'login0,*1,*[bot]'
         const org = new Org(testOrg)
 
-        assert.equal(org.isUserWhitelisted('login0'), true)
-        assert.equal(org.isUserWhitelisted('login1'), true)
-        assert.equal(org.isUserWhitelisted('user[bot]'), true)
-        assert.equal(org.isUserWhitelisted('login2'), false)
+        assert.equal(org.isUserOnAllowlist('login0'), true)
+        assert.equal(org.isUserOnAllowlist('login1'), true)
+        assert.equal(org.isUserOnAllowlist('user[bot]'), true)
+        assert.equal(org.isUserOnAllowlist('login2'), false)
     })
 
-    it('should properly parse empty whitelist pattern', async () => {
+    it('should properly parse empty allowlist', async () => {
         const testOrg = testData.org_from_db_with_empty_excluded_patterns
         const org = new Org(testOrg)
 
-        assert.equal(org.isUserWhitelisted('login0'), false)
-        assert.equal(org.isUserWhitelisted('login1'), false)
+        assert.equal(org.isUserOnAllowlist('login0'), false)
+        assert.equal(org.isUserOnAllowlist('login1'), false)
     })
 })

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -44,7 +44,7 @@ const stub = () => {
         gist: 'url/gistId',
         token: 'abc',
         sharedGist: false,
-        isUserWhitelisted: function () {
+        isUserOnAllowlist: function () {
             return false
         }
     }
@@ -493,7 +493,7 @@ describe('cla:checkPullRequestSignatures', () => {
             gist: 'url/gistId',
             sharedGist: false,
             token: 'abc',
-            isUserWhitelisted: function () {
+            isUserOnAllowlist: function () {
                 return false
             }
         }
@@ -755,8 +755,8 @@ describe('cla:checkPullRequestSignatures', () => {
         }
     })
 
-    it('should not check submitter if he/she is whitelisted', async () => {
-        testRes.repoServiceGet.isUserWhitelisted = user => user === 'login0'
+    it('should not check submitters on the allowlist', async () => {
+        testRes.repoServiceGet.isUserOnAllowlist = user => user === 'login0'
         config.server.feature_flag.required_signees = 'submitter'
         testRes.claFindOne = null
         testRes.repoServiceGetCommitters = [{
@@ -785,8 +785,8 @@ describe('cla:checkPullRequestSignatures', () => {
         }
     })
 
-    it('should exclude whitelisted committers from the map', async () => {
-        testRes.repoServiceGet.isUserWhitelisted = (user) => user === 'login1'
+    it('should exclude committers on allowlist from the map', async () => {
+        testRes.repoServiceGet.isUserOnAllowlist = (user) => user === 'login1'
         testRes.repoServiceGetCommitters = [{
             name: 'login1',
             id: '123'
@@ -851,10 +851,10 @@ describe('cla:checkPullRequestSignatures', () => {
             })
         })
 
-        it('should call callback function immediately if organization is whitelisted and there are no external committers ', async () => {
+        it('should call callback function immediately if organization is on allowlist and there are no external committers ', async () => {
             config.server.feature_flag.required_signees = 'submitter committer'
             testRes.getPR.data.head.repo.fork = false
-            testRes.repoServiceGet.isUserWhitelisted = login => login === testRes.getPR.data.head.repo.owner.login
+            testRes.repoServiceGet.isUserOnAllowlist = login => login === testRes.getPR.data.head.repo.owner.login
             testRes.repoServiceGetCommitters = [{
                 name: 'login1',
                 id: '123'
@@ -888,11 +888,11 @@ describe('cla:checkPullRequestSignatures', () => {
                 config.server.feature_flag.required_signees = ''
             }
         })
-        it('should check if the external committer has signed the CLA when the organization is whitelisted (external Organisation) ', async () => {
+        it('should check if the external committer has signed the CLA when the organization is on allowlist (external Organisation) ', async () => {
             config.server.feature_flag.required_signees = 'submitter committer'
             testRes.getPR.data.head.repo.fork = true
             testRes.getPR.data.head.repo.owner.login = 'orgLogin1'
-            testRes.repoServiceGet.isUserWhitelisted = login => login === testRes.getPR.data.head.repo.owner.login
+            testRes.repoServiceGet.isUserOnAllowlist = login => login === testRes.getPR.data.head.repo.owner.login
             testRes.repoServiceGetCommitters = [{
                 name: 'login1',
                 id: '123'
@@ -1006,7 +1006,7 @@ describe('cla:sign', () => {
             gist: 'url/gistId',
             sharedGist: false,
             token: 'abc',
-            isUserWhitelisted: function () {
+            isUserOnAllowlist: function () {
                 return false
             }
         }
@@ -1507,7 +1507,7 @@ describe('cla:getLinkedItem', () => {
             owner: 'login0',
             gist: 'url/gistId',
             token: 'abc',
-            isUserWhitelisted: function () {
+            isUserOnAllowlist: function () {
                 return false
             }
         }
@@ -1636,7 +1636,7 @@ describe('cla:terminate', () => {
             gist: 'url/gistId',
             sharedGist: false,
             token: 'abc',
-            isUserWhitelisted: function () {
+            isUserOnAllowlist: function () {
                 return false
             }
         }
@@ -1725,7 +1725,7 @@ describe('cla:isClaRequired', () => {
             owner: 'owner',
             gist: 'url/gistId',
             token: 'abc',
-            isUserWhitelisted: () => false
+            isUserOnAllowlist: () => false
         }
     })
 

--- a/src/tests/server/services/repo.js
+++ b/src/tests/server/services/repo.js
@@ -761,14 +761,14 @@ describe('repo:update', () => {
             gist: 'updated gist',
             minFileChanges: 1,
             minCodeChanges: 20,
-            whiteListPattern: 'whitelist-user',
+            allowListPattern: 'allowlist-user',
             privacyPolicy: 'http://privacy-policy',
         })
         const updatedRepo = await repo.update(args)
         assert.equal(updatedRepo.gist, args.gist)
         assert.equal(updatedRepo.minFileChanges, args.minFileChanges)
         assert.equal(updatedRepo.minCodeChanges, args.minCodeChanges)
-        assert.equal(updatedRepo.whiteListPattern, args.whiteListPattern)
+        assert.equal(updatedRepo.allowListPattern, args.allowListPattern)
         assert.equal(updatedRepo.privacyPolicy, args.privacyPolicy)
         assert(response.findOne.repo.save.calledOnce)
     })

--- a/src/tests/server/testData.js
+++ b/src/tests/server/testData.js
@@ -98,7 +98,7 @@ let testData = {
         'token': 'testToken',
         'gist': 'https://gist.github.com/aa5a315d61ae9438b18d',
         'excludePattern': 'foo,bar,baz',
-        'whiteListPattern': '',
+        'allowListPattern': '',
     },
     'org_from_db_with_empty_excluded_patterns': {
         'orgId': 1,

--- a/src/tests/server/webhooks/pull_request.js
+++ b/src/tests/server/webhooks/pull_request.js
@@ -507,10 +507,9 @@ describe('webhook pull request', () => {
         await new Promise((resolve) => setTimeout(resolve, 40))
         assert(!cla.check.called)
         assert(logger.warn.called)
-
     })
 
-    it('should set ClaNotRequired status if the pull request has only whitelisted committers', async () => {
+    it('should set ClaNotRequired status if the pull request has only committers on allowlist', async () => {
         cla.check.restore()
 
         sinon.stub(cla, 'check').resolves({
@@ -529,7 +528,6 @@ describe('webhook pull request', () => {
         await new Promise((resolve) => setTimeout(resolve, 40))
         assert(!status.update.called)
         assert(status.updateForClaNotRequired.called)
-
     })
 
     // it('should update status of PR even if repo is unknown but from known org', function() {


### PR DESCRIPTION
It is by now widely recognised (Examples: [1](https://www.cnet.com/news/master-and-slave-tech-terms-face-scrutiny-amid-anti-racism-efforts/), [2](https://www.reddit.com/r/golang/comments/gy9ylr/go_has_removed_all_uses_of_blacklistwhitelist_and/), [3](https://www.zdnet.com/article/mysql-drops-master-slave-and-blacklist-whitelist-terminology/)), that the use of the term “whitelist” is bad because of its racial overtone. So please rephrase where it is used. 

The term “allowlist” seems to be what usually supersedes the old term when used as a noun and just “allow” when used as a verb, maybe with small adjustments.