### PR TITLE
Filter Archived Repositories in getReposNeedToValidate()

### DIFF
--- a/src/server/api/cla.js
+++ b/src/server/api/cla.js
@@ -642,6 +642,11 @@ async function getReposNeedToValidate(req) {
                 return false
             }
 
+            if (repo.archived) {
+                // Archived repos can not receive commit status updates, etc.
+                return false
+            }
+
             return true
         })
     } catch (error) {

--- a/src/tests/server/api/cla.js
+++ b/src/tests/server/api/cla.js
@@ -85,13 +85,23 @@ describe('', () => {
                         login: 'two'
                     }
                 },
-                callRepos: testData.orgRepos.concat({
-                    id: 2,
-                    name: 'testRepo',
-                    owner: {
-                        login: 'org'
+                callRepos: testData.orgRepos.concat(
+                    {
+                        id: 2,
+                        name: 'testRepo',
+                        owner: {
+                            login: 'org'
+                        },
+                    },
+                    {
+                        id: 3,
+                        name: 'testArchivedRepo',
+                        owner: {
+                            login: 'org'
+                        },
+                        archived: true,
                     }
-                })
+                )
             },
             repoService: {
                 get: JSON.parse(JSON.stringify(testData.repo_from_db)), //clone object


### PR DESCRIPTION
cla-assistant does not currently exclude [archived repositories](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/archiving-repositories) within `getReposNeedToValidate`. When this method returns archived repositories _that were archived with outstanding open PRs_ we subsequently attempt to update commit statuses but fail due to: `RequestError [HttpError]: Repository was archived so is read-only.`. Given the inability to update archived repositories, it would make sense for the application to ignore them.  Anecdotally, hitting this `RequestError` is enough to cause the entire npm process to crash.

This is my first PR to the project, so please feel free to direct me to a different way to accommodate this change, etc.

Note: 
- b4586f1 adds an extra repository to the `orgRepos` test data with the `archived` attribute set to false. A couple of associated test cases fail with solely that addition as expected (since the tests' assertions are implicitly validating functionality by the number of times certain methods are called).
- d544a76 includes the functional changes to how the org repo list is filtered which returns the impacted test cases to a passing state (🤞) 