### PR TITLE
Improve Dockerfile `apk` command cache handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,12 @@ COPY . /cla-assistant
 WORKDIR /cla-assistant
 
 RUN \
-  apk add --update nodejs su-exec git curl bzip2 patch make g++ && \
+  apk add --no-cache nodejs su-exec git curl bzip2 patch make g++ && \
   addgroup -S cla-assistant && \
   adduser -S -D -G cla-assistant cla-assistant && \
   chown -R cla-assistant:cla-assistant /cla-assistant && \
   su-exec cla-assistant /bin/sh -c 'cd /cla-assistant && npm install && node_modules/grunt-cli/bin/grunt build && rm -rf /home/cla-assistant/.npm .git' && \
-  apk del git curl bzip2 patch make g++ && \
-  rm -rf /var/cache/apk/*
+  apk del git curl bzip2 patch make g++
 
 USER cla-assistant
 CMD npm start


### PR DESCRIPTION
Use `--no-cache` with `apk`, so it'll still update repository indexes,
but leave no cache in the file system, so there will be no need to
manually clean up the apk cache anymore!