### PR TITLE
Use JSON notation for CMD's arguments in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ RUN \
   apk del git curl bzip2 patch make g++
 
 USER cla-assistant
-CMD npm start
+CMD ["npm", "start"]


### PR DESCRIPTION
Reference - Best practices for writing Dockerfiles:

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#cmd

> CMD should almost always be used in the form of CMD ["executable","param1", "param2"…]