### PR TITLE
Simplify apk package clean up in Dockerfile with virtual package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,12 @@ COPY . /cla-assistant
 WORKDIR /cla-assistant
 
 RUN \
-  apk add --no-cache nodejs su-exec git curl bzip2 patch make g++ && \
+  apk add --no-cache --virtual .build-deps nodejs su-exec git curl bzip2 patch make g++ && \
   addgroup -S cla-assistant && \
   adduser -S -D -G cla-assistant cla-assistant && \
   chown -R cla-assistant:cla-assistant /cla-assistant && \
   su-exec cla-assistant /bin/sh -c 'cd /cla-assistant && npm install && node_modules/grunt-cli/bin/grunt build && rm -rf /home/cla-assistant/.npm .git' && \
-  apk del git curl bzip2 patch make g++
+  apk del .build-deps
 
 USER cla-assistant
 CMD npm start


### PR DESCRIPTION
With this approach, we won't need to write the package list twice in the beginning and the end.