### PR TITLE
Make README more inclusive

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To get started, simply store your CLA as a GitHub Gist file then link it with th
 
 - Comments on each opened pull request to ask the contributor to sign the CLA
 - Allows contributors to sign a CLA from within a pull request
-- Authenticates the signee with his or her GitHub account
+- Authenticates the signee with their GitHub account
 - Updates the status of a pull request when the contributor agrees to the CLA
 - Automatically asks users to re-sign the CLA for each new pull request in the event the associated Gist & CLA has changed
 


### PR DESCRIPTION
The README.md file currently talks about "his or her GitHub account" when refering to the users GitHub account. I changed this from "his or her" to "their" to make the README inclusive towards non-binary people.

"they/their" is commonly used in the english language to refer to people of unknown or unspecified gender, as well as people who do not align with the gender binary, and therefore preferable over "his or her", especially since many states nowadays legally recognize the existence of more than two genders. 