### PR TITLE
adjust index and cookie storage for cosmosDB

### DIFF
--- a/src/server/app.js
+++ b/src/server/app.js
@@ -165,9 +165,14 @@ async.series([
             cookie: {
                 maxAge: config.server.security.cookieMaxAge
             },
+            // cosmosDB supports only supports autoExpire on _ts fields
+            // therefore use interval based removal to workaround that
             store: new MongoStore({
                 mongooseConnection: mongoose.connection,
-                collection: 'cookieSession'
+                collection: 'cookieSession',
+                ttl: config.server.security.cookieMaxAge,
+                autoRemove: 'interval',
+                autoRemoveInterval: 10, // Value in minutes (default is 10)
             })
         }
         session.cookie.secure = app.get('env') === 'production'

--- a/src/server/documents/cla.js
+++ b/src/server/documents/cla.js
@@ -20,20 +20,19 @@ const CLASchema = mongoose.Schema({
     updated_at: Date
 })
 
+// cosmosDB supports only up to 8 combined indexes
 const index = {
-    repo: 1,
     repoId: 1,
-    owner: 1,
     ownerId: 1,
     userId: 1,
     gist_url: 1,
     gist_version: 1,
     org_cla: 1,
-    revoked_at: 1
+    revoked_at: 1,
 }
 const indexOptions = {
     unique: true,
-    partialFilterExpression: { userId: { $exists: true } },
+    // partialFilterExpression: { userId: { $exists: true } },
     background: true,
 }
 
@@ -46,7 +45,8 @@ const CLA = mongoose.model('CLA', CLASchema)
     }
 }) */
 CLA.collection.createIndex(index, indexOptions)
-
+// add a full wildcard index for better indexing
+CLA.collection.createIndex({ "$**" : 1 })
 module.exports = {
     CLA: CLA
 }


### PR DESCRIPTION
This PR adjust the index slightly to allow the usage of cosmosDB underneath. 

Changes included: 
- limit amount of items in the composed index to 8 (removing repo (name) and org (name))
- Remove partial index. Previously the constraint only applied where `userId` exists, but it should exist always?
- Add a separate index for all fields for quick access and sorting
- Adjust cookie handling to support cosmosDB as cosmosDB doesn't have an automatic TTL removal

//cc @ibakshay @michael-spengler @KharitonOff If you have further background, why this was done (e.g. the index on the userId) please let me know, so I can ensure that it doesn't break anything.