### PR TITLE
improve request performance for getSignedCLA()

### DIFF
--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -2,6 +2,7 @@
 require('../documents/cla')
 require('../documents/repo')
 require('../documents/org')
+
 const mongoose = require('mongoose')
 const CLA = mongoose.model('CLA')
 const Repository = mongoose.model('Repo')

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -1,6 +1,8 @@
 // models
 require('../documents/cla')
 const CLA = require('mongoose').model('CLA')
+const Repository = require('mongoose').model('Repo')
+const Org = require('mongoose').model('Org')
 
 //services
 const logger = require('../services/logger')
@@ -569,73 +571,65 @@ class ClaService {
         return signature
     }
 
-    //Get list of signed CLAs for all repos the user has contributed to
+    // Get list of signed CLAs for all repos/owners the user has contributed to
     async getSignedCLA(user) {
-        const selector = []
-        const date = new Date();
-        const findCla = async function (query, repoList, claList) {
-            const clas = await CLA.find(query, {
-                'repo': 1,
-                'owner': 1,
-                'created_at': 1,
-                'gist_url': 1,
-                'gist_version': 1
+        // get all ever signed CLAs for the given user/userId
+        let clas = await CLA.find({
+            $or: [{
+                user: user.login,
             }, {
-                sort: {
-                    'created_at': -1
-                }
-            })
+                userId: user.id,
+            }],
+        }, {
+            'repo': 1,
+            'owner': 1,
+            'created_at': 1,
+            'repoId': 1,
+            'gist_url': 1,
+            'gist_version': 1,
+            'revoked_at': 1,
+        }, {
+            sort: {
+                'created_at': -1
+            }
+        })
 
-            clas.forEach((cla) => {
-                if (repoList.indexOf(cla.repo) < 0) {
-                    repoList.push(cla.repo)
-                    claList.push(cla)
-                }
-            })
-        }
-        try {
-            const repos = await repoService.all()
-            repos.forEach((repo) => {
-                selector.push({
-                    user: user.login,
-                    repo: repo.repo,
-                    gist_url: repo.gist,
-                    revoked_at: {$gt: date}
-                })
-                selector.push({
-                    user: user.login,
-                    repo: repo.repo,
-                    gist_url: repo.gist,
-                    revoked_at: undefined
-                })
-            })
-        } catch (error) {
-            logger.warn(new Error(error).stack)
-        }
+        // return only the ones which are not yet revoked
+        clas = clas.filter(cla => cla.revoked_at == undefined)
+        // return empty array if we don't have any repositories anymore
+        if (clas.length == 0) { return [] }
 
-        const repoList = []
-        const uniqueClaList = []
-        try {
-            await findCla({
-                $or: selector
-            }, repoList, uniqueClaList)
-        } catch (error) {
-            logger.warn(new Error(error).stack)
-        }
-        try {
-            await findCla({
-                $or: [{
-                    user: user.login,
-                    revoked_at: {$gt: date}
-                },{
-                    user: user.login,
-                    revoked_at: undefined
-                }]
-            }, repoList, uniqueClaList)
-        } catch (error) {
-            logger.warn(new Error(error).stack)
-        }
-        return uniqueClaList
+        // find all repositories related to the clas and only return still existing repositories and where the signature is up-to-date
+        const repofilter = clas.map(cla => ({
+            owner: cla.owner,
+            gist: cla.gist_url
+        }))
+        const repos = await Repository.find({
+            $or: repofilter
+        })
+
+        // find all owners/organizations related to the clas and only return still existing owners and where the signature is up-to-date
+        const ownerfilter = clas.map(cla => ({
+            org: cla.owner,
+            gist: cla.gist_url
+        }))
+        const owners = await Org.find({
+            $or: ownerfilter
+        })
+
+        // filter if its an org CLA (repo == undefined) or if repo exists
+        clas = clas.filter(cla => {
+            // check if it is an owner or repo configuration
+            // if repo is undefined it is an org/owner wide cla
+            if (cla.repo == undefined) {
+                // if owner and gist matches return cla
+                return owners.find(owner => owner.org == cla.owner && owner.gist == cla.gist_url)
+            } else {
+                // if repo, owner and gist matches return cla
+                return repos.find(repo => repo.repo == cla.repo && repo.owner == cla.owner && repo.gist == cla.gist_url)
+            }
+        })
+        return clas
     }
 
     // Get linked repo or org
@@ -764,9 +758,9 @@ class ClaService {
     }
 
     async revoke(args, user) {
-        const cla = await CLA.findOne({_id: args._id});
+        const cla = await CLA.findOne({ _id: args._id });
 
-        if(user.id !== Number(cla.userId)) {
+        if (user.id !== Number(cla.userId)) {
             logger.error('User: ' + cla.user + ' is unauthorized to revoke cla with id: ' + cla._id);
             throw new Error('Unauthorized to revoke CLA');
         }

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -624,10 +624,9 @@ class ClaService {
             if (cla.repo == undefined) {
                 // if owner and gist matches return cla
                 return owners.find(owner => owner.org == cla.owner && owner.gist == cla.gist_url)
-            } else {
-                // if repo, owner and gist matches return cla
-                return repos.find(repo => repo.repo == cla.repo && repo.owner == cla.owner && repo.gist == cla.gist_url)
             }
+            // if repo, owner and gist matches return cla
+            return repos.find(repo => repo.repo == cla.repo && repo.owner == cla.owner && repo.gist == cla.gist_url)
         })
         return clas
     }

--- a/src/server/services/cla.js
+++ b/src/server/services/cla.js
@@ -592,6 +592,7 @@ class ClaService {
             'gist_url': 1,
             'gist_version': 1,
             'revoked_at': 1,
+            'org_cla': 1,
         }, {
             sort: {
                 'created_at': -1
@@ -621,11 +622,10 @@ class ClaService {
             $or: ownerfilter
         })
 
-        // filter if its an org CLA (repo == undefined) or if repo exists
+        // filter if its an org CLA (org_cla == true) or if repo exists
         clas = clas.filter(cla => {
-            // check if it is an owner or repo configuration
-            // if repo is undefined it is an org/owner wide cla
-            if (cla.repo == undefined) {
+            // if org_cla is true it is an organization based CLA
+            if (cla.org_cla) {
                 // if owner and gist matches return cla
                 return owners.find(owner => owner.org == cla.owner && owner.gist == cla.gist_url )
             }

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -1274,23 +1274,23 @@ describe('cla:getSignedCLA', () => {
             return []
         })
 
-        sinon.stub(CLA, 'find').callsFake(async (arg) => {
-            let listOfAllCla = [{
+        sinon.stub(CLA, 'find').callsFake(async () => {
+            return [{
                 repo: 'repo1',
                 user: 'login',
-                owner: "owner1",
+                owner: 'owner1',
                 gist_url: 'gist_url1',
                 created_at: '2011-06-20T11:34:15Z'
             }, {
                 repo: 'repo1',
                 user: 'login',
-                owner: "owner1",
+                owner: 'owner1',
                 gist_url: 'gist_url2',
                 created_at: '2011-06-15T11:34:15Z'
             }, {
                 repo: 'repo2',
                 user: 'login',
-                owner: "owner1",
+                owner: 'owner1',
                 gist_url: 'gist_url',
                 created_at: '2011-06-15T11:34:15Z'
             }, {
@@ -1303,9 +1303,7 @@ describe('cla:getSignedCLA', () => {
                 user: 'login',
                 gist_url: 'gist_url',
                 created_at: '2011-06-15T11:34:15Z'
-            }
-            ]
-            return listOfAllCla
+            }]
         })
 
         const args = {

--- a/src/tests/server/services/cla.js
+++ b/src/tests/server/services/cla.js
@@ -7,13 +7,14 @@ const sinon = require('sinon')
 const CLA = require('../../../server/documents/cla').CLA
 const Org = require('../../../server/documents/org').Org
 const Repository = require('../../../server/documents/repo').Repo
+
 //services
 const org_service = require('../../../server/services/org')
 const repo_service = require('../../../server/services/repo')
 const github = require('../../../server/services/github')
 const logger = require('../../../server/services/logger')
-
 const config = require('../../../config')
+
 // test data
 const testData = require('../testData').data
 


### PR DESCRIPTION
This PR improves the performance of getSignedCLA() massively. 
On an instance with a lot of configured repos (like cla-assistant.io) the current implementation gets a big list of repos first and then performs a second request to determine for which of these the user has a signature on file

This implementation reverses the request order and first requests all CLAs the user has signed and then performs the lookup of repos/orgs to check if that is still the up-to-date CLA. Generally this performs way better as a lot less data needs to be transferred. In my tests I saw an improvement down from a dozen seconds to less than a second. 

Follow up to #688 //cc @rael312