### PR TITLE
add option to associate logs with request ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ The following are the environment variables you have to configure to run a priva
 - `MONGODB`: This has to be in form of a mongodb url, e.g. `mongodb://<user>:<password>@<host>:<port>/<dbname>`.
 - `SLACK_URL`: Optional. You can use it in case you would like to get log-notifications posted in your slack chat.
 - `SLACK_TOKEN`: Optional.
+- `REQUEST_TRACE_HEADER_NAME`: Use the value of an HTTP-header to set the name. E.g. the request id set by an ingress controller via `X-Req-Id`. If not set or no HTTP-header is present a random uuid is used.
+- `LOG_TRACE_FIELD_NAME`: The log field to log the request id to. Defaults to `req_id`.
 
 > **Hint:** For further reading on setting up MongoDB, check the "[Getting Started](http://docs.mongodb.org/manual/tutorial/getting-started/)" and [`db.createUser()` method](http://docs.mongodb.org/manual/reference/method/db.createUser).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "bower": "^1.8.8",
                 "bunyan": "^1.8.12",
                 "bunyan-slack": "0.0.10",
+                "cls-rtracer": "^2.6.0",
                 "codeceptjs": "^2.0.7",
                 "colors": "^1.3.3",
                 "connect-mongo": "^2.0.3",
@@ -1788,6 +1789,25 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
             "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+        },
+        "node_modules/cls-rtracer": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/cls-rtracer/-/cls-rtracer-2.6.0.tgz",
+            "integrity": "sha512-AkerGNOczlS5mj7giIGi0KvqwLy2sckUF7RQe5r0dV4Z/SWUclUwVEhIOJQ3rOcTOBqlBVAtmGbSWirkW1GK4w==",
+            "dependencies": {
+                "uuid": "8.3.1"
+            },
+            "engines": {
+                "node": ">=12.17.0 <13.0.0 || >=13.14.0 <14.0.0 || >=14.0.0"
+            }
+        },
+        "node_modules/cls-rtracer/node_modules/uuid": {
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+            "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/co": {
             "version": "4.6.0",
@@ -13382,6 +13402,21 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
             "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+        },
+        "cls-rtracer": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/cls-rtracer/-/cls-rtracer-2.6.0.tgz",
+            "integrity": "sha512-AkerGNOczlS5mj7giIGi0KvqwLy2sckUF7RQe5r0dV4Z/SWUclUwVEhIOJQ3rOcTOBqlBVAtmGbSWirkW1GK4w==",
+            "requires": {
+                "uuid": "8.3.1"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+                    "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+                }
+            }
         },
         "co": {
             "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "bower": "^1.8.8",
         "bunyan": "^1.8.12",
         "bunyan-slack": "0.0.10",
+        "cls-rtracer": "^2.6.0",
         "codeceptjs": "^2.0.7",
         "colors": "^1.3.3",
         "connect-mongo": "^2.0.3",

--- a/src/config.js
+++ b/src/config.js
@@ -109,6 +109,11 @@ module.exports = {
             organization_override_enabled: process.env.ORG_OVERRIDE_ENABLED || false,
         },
 
+        observability: {
+            request_trace_header_name: process.env.REQUEST_TRACE_HEADER_NAME,
+            log_trace_field_name: process.env.LOG_TRACE_FIELD_NAME || 'req_id',
+        },
+
         static: [
             path.join(__dirname, 'bower'),
             path.join(__dirname, 'client')

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -15,6 +15,8 @@ const path = require('path')
 const cleanup = require('./middleware/cleanup')
 const noSniff = require('dont-sniff-mimetype')
 const mongoose = require('mongoose')
+const rTracer = require('cls-rtracer')
+
 // var sass_middleware = require('node-sass-middleware');
 
 // ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -27,10 +29,20 @@ global.config = require('./../config')
 // Express application
 // ////////////////////////////////////////////////////////////////////////////////////////////////
 
+const log = require('./services/logger')
+
 const app = express()
 const api = {}
 const webhooks = {}
 let runningWebhooks = []
+
+// install tracing middleware
+const tracingOptions = {}
+if (config.server.observability.request_trace_header_name) {
+    tracingOptions.useHeader = true
+    tracingOptions.headerName = config.server.observability.request_trace_header_name
+}
+app.use(rTracer.expressMiddleware(tracingOptions))
 
 // redirect from http to https
 app.use((req, res, next) => {
@@ -61,11 +73,6 @@ app.use('/api', require('./middleware/param'))
 app.use('/github', require('./middleware/param'))
 app.use('/accept', require('./middleware/param'))
 app.use('/count', require('./middleware/param'))
-
-// app.use(function (err, req, res, next) {
-//     var log = require('./services/logger');
-//     log.info('app error: ', err.stack);
-// });
 
 const bootstrap = (files, callback) => {
     console.log('bootstrap'.bold, files.bold);
@@ -198,7 +205,7 @@ async.series([
     if (err) {
         console.log('! '.yellow + err)
     }
-    const log = require('./services/logger')
+
 
     console.log(`${'\n✓ '.bold.green}bootstrapped for ${app.get('env')}, app listening on ${config.server.http.host}:${config.server.localport}`.bold)
     log.info(`✓ bootstrapped for ${app.get('env')}!!! App listening on ${config.server.http.host}:${config.server.http.port}`)
@@ -298,15 +305,3 @@ function retryInitializeMongoose(uri, options, callback) {
 }
 
 module.exports = app
-// async function retryInitializeMongoose(uri, options) {
-//     const defaultInterval = 1000
-//     try {
-//         await mongoose.connect(uri, options);
-//     } catch (err) {
-//         console.log(err, `Retry initialize mongoose in ${options.retryInitializeInterval || defaultInterval} milliseconds`)
-//         setTimeout(() => {
-//             retryInitializeMongoose(uri, options)
-//         }, options.retryInitializeInterval || defaultInterval)
-
-//     }
-// }

--- a/src/server/services/logger.js
+++ b/src/server/services/logger.js
@@ -9,15 +9,13 @@ const formatter = (record, levelName) => {
     }
 }
 
-function wrappedStdout() {
-    return {
+// we use a custom Stdout writer, which injects for each call the request id
+const wrappedStdout = {
         write: entry => {
-            // we use a custom Stdout writer, which injects for each call the req_id
             const logObject = JSON.parse(entry)
             logObject[config.server.observability.log_trace_field_name] = rTracer.id();
             process.stdout.write(JSON.stringify(logObject) + '\n');
         }
-    }
 }
 
 log = bunyan.createLogger({
@@ -26,7 +24,7 @@ log = bunyan.createLogger({
     streams: [{
         name: 'stdout',
         level: process.env.ENV == 'debug' ? 'info' : 'debug',
-        stream: wrappedStdout(),
+        stream: wrappedStdout,
     }]
 });
 

--- a/src/server/services/logger.js
+++ b/src/server/services/logger.js
@@ -1,7 +1,6 @@
 const bunyan = require('bunyan')
 const BunyanSlack = require('bunyan-slack')
 const rTracer = require('cls-rtracer')
-let log
 
 const formatter = (record, levelName) => {
     return {
@@ -18,7 +17,7 @@ const wrappedStdout = {
         }
 }
 
-log = bunyan.createLogger({
+const log = bunyan.createLogger({
     src: true,
     name: config.server.http.host,
     streams: [{


### PR DESCRIPTION
This PR uses the automatic context location via `cls-rtracer` to figure out to which http request a logging statement is associated and injects this information into the log output. 
This is very helpful to associate log entries with HTTP requests and can be used in `cla-assistant.io` to link logs to traces in GCP Cloud Logging.

Adds two environment variables to determine behavior: 
- `REQUEST_TRACE_HEADER_NAME`: Use the value of an HTTP-header to set the name. E.g. the request Id set by Cloud Run (or an ingress controller). If not set or no HTTP-header is present a random uuid is used.
- `LOG_TRACE_FIELD_NAME`: The log field to use. Defaults to `req_id`. 
