### PR TITLE
add trace prefix and support for traceparent opentelemetry header

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The following are the environment variables you have to configure to run a priva
 - `SLACK_TOKEN`: Optional.
 - `REQUEST_TRACE_HEADER_NAME`: Use the value of an HTTP-header to set the name. E.g. the request id set by an ingress controller via `X-Req-Id`. If not set or no HTTP-header is present a random uuid is used.
 - `LOG_TRACE_FIELD_NAME`: The log field to log the request id to. Defaults to `req_id`.
+- `LOG_TRACE_PREFIX`: A prefix put before the traceId.
 
 > **Hint:** For further reading on setting up MongoDB, check the "[Getting Started](http://docs.mongodb.org/manual/tutorial/getting-started/)" and [`db.createUser()` method](http://docs.mongodb.org/manual/reference/method/db.createUser).
 

--- a/src/config.js
+++ b/src/config.js
@@ -112,6 +112,7 @@ module.exports = {
         observability: {
             request_trace_header_name: process.env.REQUEST_TRACE_HEADER_NAME,
             log_trace_field_name: process.env.LOG_TRACE_FIELD_NAME || 'req_id',
+            trace_prefix: process.env.LOG_TRACE_PREFIX || '',
         },
 
         static: [

--- a/src/server/services/logger.js
+++ b/src/server/services/logger.js
@@ -15,7 +15,7 @@ const wrappedStdout = {
         let traceId = rTracer.id()
         if (traceId) {
             if (config.server.observability.request_trace_header_name == 'traceparent') {
-                traceParts = traceId.split('-');
+                const traceParts = traceId.split('-');
                 // check if it conforms to version 00 of opentelemetry spec (https://www.w3.org/TR/trace-context)
                 // version "-" trace-id "-" parent-id "-" trace-flags
                 if (traceParts.length == 4 && traceParts[0] == '00') {

--- a/src/server/services/logger.js
+++ b/src/server/services/logger.js
@@ -10,11 +10,22 @@ const formatter = (record, levelName) => {
 
 // we use a custom Stdout writer, which injects for each call the request id
 const wrappedStdout = {
-        write: entry => {
-            const logObject = JSON.parse(entry)
-            logObject[config.server.observability.log_trace_field_name] = rTracer.id();
-            process.stdout.write(JSON.stringify(logObject) + '\n');
+    write: entry => {
+        const logObject = JSON.parse(entry)
+        let traceId = rTracer.id()
+        if (traceId) {
+            if (config.server.observability.request_trace_header_name == 'traceparent') {
+                traceParts = traceId.split('-');
+                // check if it conforms to version 00 of opentelemetry spec (https://www.w3.org/TR/trace-context)
+                // version "-" trace-id "-" parent-id "-" trace-flags
+                if (traceParts.length == 4 && traceParts[0] == '00') {
+                    traceId = traceParts[1]
+                }
+            }
+            logObject[config.server.observability.log_trace_field_name] = `${config.server.observability.trace_prefix}${traceId}`;
         }
+        process.stdout.write(JSON.stringify(logObject) + '\n');
+    }
 }
 
 const log = bunyan.createLogger({


### PR DESCRIPTION
This PR adds support for a trace prefix via `LOG_TRACE_PREFIX`. 
Additionally it adds support for opentelemtry style `traceparent` headers.