### PR TITLE
use node-fetch; remove request(-promise-native)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,13 +36,11 @@
                 "memory-cache": "^0.2.0",
                 "merge": ">=1.2.1",
                 "mongoose": "^5.7.5",
-                "node-fetch": "^2.6.1",
+                "node-fetch": "^2.6.2",
                 "passport": "^0.4.0",
                 "passport-accesstoken": "^0.1.0",
                 "passport-github": "^1.1.0",
                 "q": "^1.5.1",
-                "request": "^2.88.0",
-                "request-promise-native": "^1.0.7",
                 "x-frame-options": "^1.0.0"
             },
             "devDependencies": {
@@ -8016,9 +8014,9 @@
             }
         },
         "node_modules/node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+            "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
             "engines": {
                 "node": "4.x || >=6.0.0"
             }
@@ -9150,30 +9148,6 @@
             "dev": true,
             "dependencies": {
                 "throttleit": "^1.0.0"
-            }
-        },
-        "node_modules/request-promise-core": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
-            "dependencies": {
-                "lodash": "^4.17.11"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/request-promise-native": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
-            "dependencies": {
-                "request-promise-core": "1.1.2",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
-            },
-            "engines": {
-                "node": ">=0.12.0"
             }
         },
         "node_modules/request/node_modules/qs": {
@@ -10732,14 +10706,6 @@
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/stealthy-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/stream-events": {
@@ -18491,9 +18457,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+            "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         },
         "node-forge": {
             "version": "0.9.1",
@@ -19387,24 +19353,6 @@
             "dev": true,
             "requires": {
                 "throttleit": "^1.0.0"
-            }
-        },
-        "request-promise-core": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
-            "requires": {
-                "lodash": "^4.17.11"
-            }
-        },
-        "request-promise-native": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
-            "requires": {
-                "request-promise-core": "1.1.2",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
             }
         },
         "require_optional": {
@@ -20705,11 +20653,6 @@
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-        },
-        "stealthy-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
         },
         "stream-events": {
             "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,11 @@
         "memory-cache": "^0.2.0",
         "merge": ">=1.2.1",
         "mongoose": "^5.7.5",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.2",
         "passport": "^0.4.0",
         "passport-accesstoken": "^0.1.0",
         "passport-github": "^1.1.0",
         "q": "^1.5.1",
-        "request": "^2.88.0",
-        "request-promise-native": "^1.0.7",
         "x-frame-options": "^1.0.0"
     },
     "devDependencies": {

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -1,5 +1,4 @@
-const request = require('request-promise-native')
-
+const fetch = require('node-fetch')
 const cache = require('memory-cache')
 const config = require('../../config')
 let Octokit = require('@octokit/rest')
@@ -120,12 +119,12 @@ const githubService = {
     },
 
     callGraphql: async (query, token) => {
-        return request.post({
+        return fetch(config.server.github.graphqlEndpoint, {
+            method: 'POST',
             headers: {
                 'Authorization': `bearer ${token}`,
                 'User-Agent': 'CLA assistant'
             },
-            url: config.server.github.graphqlEndpoint,
             body: query
         })
     }


### PR DESCRIPTION
This PR removes the explicit usage of the deprecated `request` and `request-promise-native` library. 
Some dependencies are still using it, but we then have no explicit dependency on these.
It also bumps `node-fetch` to `2.6.2` to be inline with the other `node-fetch` versions (indirect dependencies of octokit libraries) 