### PR TITLE
fix usage of node-fetch

### DIFF
--- a/src/server/api/org.js
+++ b/src/server/api/org.js
@@ -80,8 +80,7 @@ class OrgAPI {
             const query = arg.query ? arg.query : queries.getUserOrgs(req.user.login, null)
 
             try {
-                let body = await github.callGraphql(query, req.user.token)
-                body = JSON.parse(body)
+                const body = await github.callGraphql(query, req.user.token)
 
                 if (body.errors) {
                     const errorMessage = body.errors[0] && body.errors[0].message ? body.errors[0].message : 'Error occurred by getting users organizations'

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -119,14 +119,17 @@ const githubService = {
     },
 
     callGraphql: async (query, token) => {
-        return fetch(config.server.github.graphqlEndpoint, {
+        const response = await fetch(config.server.github.graphqlEndpoint, {
             method: 'POST',
             headers: {
                 'Authorization': `bearer ${token}`,
-                'User-Agent': 'CLA assistant'
+                'User-Agent': 'CLA assistant',
+                'Content-Type': 'application/json',
             },
             body: query
         })
+        const dataPromise = response.json()
+        return dataPromise
     }
 }
 

--- a/src/server/services/repo.js
+++ b/src/server/services/repo.js
@@ -164,9 +164,8 @@ class RepoService {
                 let committers = []
                 let query = arg.query ? arg.query : queries.getPRCommitters(arg.arg.owner, arg.arg.repo, arg.arg.number, '')
 
-                let body = await github.callGraphql(query, arg.token)
+                const body = await github.callGraphql(query, arg.token)
 
-                body = JSON.parse(body)
                 if (body.errors) {
                     logger.info(new Error(body.errors[0].message).stack)
                 }

--- a/src/tests/server/api/org.js
+++ b/src/tests/server/api/org.js
@@ -48,7 +48,7 @@ describe('org api', () => {
             if (testErr.githubCallGraphql) {
                 throw new Error(testErr.githubCallGraphql)
             }
-            return JSON.stringify(testRes.githubCallGraphql.body)
+            return testRes.githubCallGraphql.body
         })
         sinon.stub(github, 'call').callsFake(async (args) => {
             if (args.fun === 'getOrgs') {

--- a/src/tests/server/services/repo.js
+++ b/src/tests/server/services/repo.js
@@ -209,7 +209,7 @@ describe('repo:getPRCommitters', () => {
             if (githubCallGraphqlRes.getPRCommitters.err) {
                 throw new Error(githubCallGraphqlRes.getPRCommitters.err)
             }
-            return JSON.stringify(githubCallGraphqlRes.getPRCommitters.body)
+            return githubCallGraphqlRes.getPRCommitters.body
         })
 
         sinon.stub(orgService, 'get').callsFake(async () => testOrg)
@@ -489,7 +489,7 @@ describe('repo:getPRCommitters', () => {
         github.callGraphql.onFirstCall().rejects({
             message: 'Moved Permanently'
         })
-        github.callGraphql.onSecondCall().resolves(JSON.stringify(githubCallGraphqlRes.getPRCommitters.body))
+        github.callGraphql.onSecondCall().resolves(githubCallGraphqlRes.getPRCommitters.body)
 
         sinon.stub(repo, 'getGHRepo').callsFake(async () => {
             return {


### PR DESCRIPTION
This PR fixes the usage of node-fetch as introduced in #754. 

`callGraphql()` now return a promise of the object and not a full request object anymore.