### PR TITLE
update @google-cloud/trace-agent to 5.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,11 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "cla-assistant",
             "version": "1.8.3",
             "license": "Apache-2.0",
             "dependencies": {
-                "@google-cloud/trace-agent": "^4.2.5",
+                "@google-cloud/trace-agent": "^5.1.5",
                 "@octokit/plugin-retry": "^2.2.0",
                 "@octokit/plugin-throttling": "^2.4.0",
                 "@octokit/rest": "^16.37.0",
@@ -148,22 +149,22 @@
             }
         },
         "node_modules/@google-cloud/common": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.4.0.tgz",
-            "integrity": "sha512-zWFjBS35eI9leAHhjfeOYlK5Plcuj/77EzstnrJIZbKgF/nkqjcQuGiMCpzCwOfPyUbz8ZaEOYgbHa759AKbjg==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.7.2.tgz",
+            "integrity": "sha512-5Q9f74IbZaY6xAwJSNFy5SrGwbm1j7mpv+6A/r+K2dymjsXBH5UauB0tziaMwWoVVaMq1IQnZF9lgtfqqvxcUg==",
             "dependencies": {
-                "@google-cloud/projectify": "^1.0.0",
-                "@google-cloud/promisify": "^1.0.0",
-                "arrify": "^2.0.0",
-                "duplexify": "^3.6.0",
+                "@google-cloud/projectify": "^2.0.0",
+                "@google-cloud/promisify": "^2.0.0",
+                "arrify": "^2.0.1",
+                "duplexify": "^4.1.1",
                 "ent": "^2.2.0",
                 "extend": "^3.0.2",
-                "google-auth-library": "^5.5.0",
-                "retry-request": "^4.0.0",
-                "teeny-request": "^6.0.0"
+                "google-auth-library": "^7.0.2",
+                "retry-request": "^4.2.2",
+                "teeny-request": "^7.0.0"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/@google-cloud/common/node_modules/arrify": {
@@ -175,33 +176,34 @@
             }
         },
         "node_modules/@google-cloud/projectify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.4.tgz",
-            "integrity": "sha512-ZdzQUN02eRsmTKfBj9FDL0KNDIFNjBn/d6tHQmA/+FImH5DO6ZV8E7FzxMgAUiVAUq41RFAkb25p1oHOZ8psfg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
+            "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ==",
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/@google-cloud/promisify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
-            "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
+            "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA==",
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/@google-cloud/trace-agent": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-4.2.5.tgz",
-            "integrity": "sha512-gVx+7NC5bwVtIZ/Z7jUbnvytwFS1RhF3iWiMyPRKWDohmy5Ixs/QK0fJNgr4Ugs12nstrILG7VfC09q8FOsK4g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-5.1.5.tgz",
+            "integrity": "sha512-8Mrspg9nebd1VA4xC+XQTBBY3PV3SoUR70CHc3waN9lZskrCQO0Ha50VamhtUx8gUMgUK8ANed5EsF8rv+jY4Q==",
             "dependencies": {
-                "@google-cloud/common": "^2.0.0",
-                "@opencensus/propagation-stackdriver": "0.0.19",
+                "@google-cloud/common": "^3.0.0",
+                "@opencensus/propagation-stackdriver": "0.1.0",
                 "builtin-modules": "^3.0.0",
                 "console-log-level": "^1.4.0",
                 "continuation-local-storage": "^3.2.1",
                 "extend": "^3.0.2",
-                "gcp-metadata": "^3.0.0",
+                "gcp-metadata": "^4.0.0",
+                "google-auth-library": "^7.0.0",
                 "hex2dec": "^1.0.1",
                 "is": "^3.2.0",
                 "methods": "^1.1.1",
@@ -209,10 +211,10 @@
                 "semver": "^7.0.0",
                 "shimmer": "^1.2.0",
                 "source-map-support": "^0.5.16",
-                "uuid": "^3.0.1"
+                "uuid": "^8.0.0"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/@google-cloud/trace-agent/node_modules/semver": {
@@ -224,6 +226,14 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@google-cloud/trace-agent/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@octokit/endpoint": {
@@ -305,36 +315,74 @@
             }
         },
         "node_modules/@opencensus/core": {
-            "version": "0.0.19",
-            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.19.tgz",
-            "integrity": "sha512-Y5QXa7vggMU0+jveLcworfX9jNnztix7x1NraAV0uGkTp4y46HrFl0DnNcnNxUDvBu/cYeWRwlmhiWlr9+adOQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.1.0.tgz",
+            "integrity": "sha512-Bdbi5vi44a1fwyHNyKh6bwzuFZJeZJPhzdwogk/Kw5juoEeRGPworK1sgtB3loeR8cqLyi5us0mz9h0xqINiSQ==",
             "dependencies": {
                 "continuation-local-storage": "^3.2.1",
                 "log-driver": "^1.2.7",
-                "semver": "^6.0.0",
+                "semver": "^7.0.0",
                 "shimmer": "^1.2.0",
-                "uuid": "^3.2.1"
+                "uuid": "^8.0.0"
             },
             "engines": {
                 "node": ">=8"
             }
         },
-        "node_modules/@opencensus/core/node_modules/semver": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "bin": {
-                "semver": "bin/semver.js"
+        "node_modules/@opencensus/core/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
-        "node_modules/@opencensus/propagation-stackdriver": {
-            "version": "0.0.19",
-            "resolved": "https://registry.npmjs.org/@opencensus/propagation-stackdriver/-/propagation-stackdriver-0.0.19.tgz",
-            "integrity": "sha512-TTL9KIOkvTpd+DT2gj3R3JP7XqOAf69ab/wzxIwpBlFqfRiIFBkOALyC/Gy4pKooAe5DemDhXZuRtIa0PgfoZQ==",
+        "node_modules/@opencensus/core/node_modules/semver": {
+            "version": "7.3.5",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+            "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
             "dependencies": {
-                "@opencensus/core": "^0.0.19",
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/@opencensus/core/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/@opencensus/core/node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "node_modules/@opencensus/propagation-stackdriver": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@opencensus/propagation-stackdriver/-/propagation-stackdriver-0.1.0.tgz",
+            "integrity": "sha512-YLklu8jnnYKaJ8gUFz3rM0FVdsWXEJAMLzeeU4JRac6LI34raENy4kvRezZtNEFS5KthaJUsYg04sPc/Ag0w4w==",
+            "dependencies": {
+                "@opencensus/core": "^0.1.0",
                 "hex2dec": "^1.0.1",
-                "uuid": "^3.2.1"
+                "uuid": "^8.0.0"
+            }
+        },
+        "node_modules/@opencensus/propagation-stackdriver/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/@sinonjs/commons": {
@@ -374,9 +422,9 @@
             "dev": true
         },
         "node_modules/@tootallnate/once": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
-            "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
             "engines": {
                 "node": ">= 6"
             }
@@ -629,9 +677,9 @@
             "dev": true
         },
         "node_modules/agent-base": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-            "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "dependencies": {
                 "debug": "4"
             },
@@ -640,11 +688,19 @@
             }
         },
         "node_modules/agent-base/node_modules/debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dependencies": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/agent-base/node_modules/ms": {
@@ -1224,9 +1280,9 @@
             }
         },
         "node_modules/bignumber.js": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-            "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
             "engines": {
                 "node": "*"
             }
@@ -2648,14 +2704,27 @@
             "dev": true
         },
         "node_modules/duplexify": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
             "dependencies": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/duplexify/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/ecc-jsbn": {
@@ -3548,9 +3617,9 @@
             "dev": true
         },
         "node_modules/fast-text-encoding": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
-            "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+            "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
         },
         "node_modules/faye-websocket": {
             "version": "0.10.0",
@@ -4674,26 +4743,29 @@
             "dev": true
         },
         "node_modules/gaxios": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.1.tgz",
-            "integrity": "sha512-DQOesWEx59/bm63lTX0uHDDXpGTW9oKqNsoigwCoRe2lOb5rFqxzHjLTa6aqEBecLcz69dHLw7rbS068z1fvIQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.1.tgz",
+            "integrity": "sha512-9qXV7yrMCGzTrphl9/YGMVH41oSg0rhn1j3wJWed4Oqk45/hXDD2wBT5J1NjQcqTCcv4g3nFnyQ7reSRHNgBgw==",
             "dependencies": {
                 "abort-controller": "^3.0.0",
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^5.0.0",
                 "is-stream": "^2.0.0",
-                "node-fetch": "^2.3.0"
+                "node-fetch": "^2.6.1"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/gaxios/node_modules/is-stream": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "engines": {
                 "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/gaze": {
@@ -4709,15 +4781,15 @@
             }
         },
         "node_modules/gcp-metadata": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.4.0.tgz",
-            "integrity": "sha512-fizmBtCXHp8b7FZuzbgKaixO8DzsSYoEVmMgZIna7x8t6cfBF3eqirODWYxVbgmasA5qudCAKiszfB7yVwroIQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+            "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
             "dependencies": {
-                "gaxios": "^2.1.0",
-                "json-bigint": "^0.3.0"
+                "gaxios": "^4.0.0",
+                "json-bigint": "^1.0.0"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/get-caller-file": {
@@ -4866,22 +4938,22 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
-            "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.9.1.tgz",
+            "integrity": "sha512-cWGykH2WBR+UuYPGRnGVZ6Cjq2ftQiEIFjQWNIRIauZH7hUWoYTr/lkKUqLTYt5dex77nlWWVQ8aPV80mhfp5w==",
             "dependencies": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
                 "fast-text-encoding": "^1.0.0",
-                "gaxios": "^2.1.0",
-                "gcp-metadata": "^3.4.0",
-                "gtoken": "^4.1.0",
+                "gaxios": "^4.0.0",
+                "gcp-metadata": "^4.2.0",
+                "gtoken": "^5.0.4",
                 "jws": "^4.0.0",
-                "lru-cache": "^5.0.0"
+                "lru-cache": "^6.0.0"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/google-auth-library/node_modules/arrify": {
@@ -4893,30 +4965,33 @@
             }
         },
         "node_modules/google-auth-library/node_modules/lru-cache": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-            "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dependencies": {
-                "yallist": "^3.0.2"
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/google-auth-library/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/google-p12-pem": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
-            "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
+            "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
             "dependencies": {
-                "node-forge": "^0.9.0"
+                "node-forge": "^0.10.0"
             },
             "bin": {
                 "gp12-pem": "build/src/bin/gp12-pem.js"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/graceful-fs": {
@@ -5473,17 +5548,16 @@
             }
         },
         "node_modules/gtoken": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
-            "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
+            "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
             "dependencies": {
-                "gaxios": "^2.1.0",
-                "google-p12-pem": "^2.0.0",
-                "jws": "^4.0.0",
-                "mime": "^2.2.0"
+                "gaxios": "^4.0.0",
+                "google-p12-pem": "^3.0.3",
+                "jws": "^4.0.0"
             },
             "engines": {
-                "node": ">=8.10.0"
+                "node": ">=10"
             }
         },
         "node_modules/gzip-size": {
@@ -5842,11 +5916,19 @@
             }
         },
         "node_modules/http-proxy-agent/node_modules/debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dependencies": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/http-proxy-agent/node_modules/ms": {
@@ -5887,11 +5969,19 @@
             }
         },
         "node_modules/https-proxy-agent/node_modules/debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dependencies": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/https-proxy-agent/node_modules/ms": {
@@ -6704,11 +6794,11 @@
             }
         },
         "node_modules/json-bigint": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
-            "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
             "dependencies": {
-                "bignumber.js": "^7.0.0"
+                "bignumber.js": "^9.0.0"
             }
         },
         "node_modules/json-schema": {
@@ -7517,6 +7607,7 @@
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
             "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+            "dev": true,
             "bin": {
                 "mime": "cli.js"
             },
@@ -8245,11 +8336,11 @@
             }
         },
         "node_modules/node-forge": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-            "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
             "engines": {
-                "node": ">= 4.5.0"
+                "node": ">= 6.0.0"
             }
         },
         "node_modules/nopt": {
@@ -9131,7 +9222,8 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -9273,6 +9365,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -9593,23 +9686,31 @@
             }
         },
         "node_modules/retry-request": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
-            "integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+            "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
             "dependencies": {
                 "debug": "^4.1.1",
-                "through2": "^3.0.1"
+                "extend": "^3.0.2"
             },
             "engines": {
                 "node": ">=8.10.0"
             }
         },
         "node_modules/retry-request/node_modules/debug": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dependencies": {
-                "ms": "^2.1.1"
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
             }
         },
         "node_modules/retry-request/node_modules/ms": {
@@ -11293,15 +11394,26 @@
             "optional": true
         },
         "node_modules/teeny-request": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.2.tgz",
-            "integrity": "sha512-B6fxA0fSnY/bul06NggdN1nywtr5U5Uvt96pHfTi8pi4MNe6++VUWcAAFBrcMeha94s+gULwA5WvagoSZ+AcYg==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.2.tgz",
+            "integrity": "sha512-Mr4NYZuniKDpgcLxdBkDE1CcWy98Aw1ennn6oNofen+XWUvDs+ZZzBAujy6XOAVwwLLZMwEQSfdljUI+ebs4Ww==",
             "dependencies": {
                 "http-proxy-agent": "^4.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.2.0",
+                "node-fetch": "^2.6.1",
                 "stream-events": "^1.0.5",
-                "uuid": "^3.3.2"
+                "uuid": "^8.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/teeny-request/node_modules/uuid": {
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/text-table": {
@@ -11321,14 +11433,6 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
-        },
-        "node_modules/through2": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-            "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-            "dependencies": {
-                "readable-stream": "2 || 3"
-            }
         },
         "node_modules/tiny-lr": {
             "version": "1.1.1",
@@ -12346,19 +12450,19 @@
             "dev": true
         },
         "@google-cloud/common": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.4.0.tgz",
-            "integrity": "sha512-zWFjBS35eI9leAHhjfeOYlK5Plcuj/77EzstnrJIZbKgF/nkqjcQuGiMCpzCwOfPyUbz8ZaEOYgbHa759AKbjg==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.7.2.tgz",
+            "integrity": "sha512-5Q9f74IbZaY6xAwJSNFy5SrGwbm1j7mpv+6A/r+K2dymjsXBH5UauB0tziaMwWoVVaMq1IQnZF9lgtfqqvxcUg==",
             "requires": {
-                "@google-cloud/projectify": "^1.0.0",
-                "@google-cloud/promisify": "^1.0.0",
-                "arrify": "^2.0.0",
-                "duplexify": "^3.6.0",
+                "@google-cloud/projectify": "^2.0.0",
+                "@google-cloud/promisify": "^2.0.0",
+                "arrify": "^2.0.1",
+                "duplexify": "^4.1.1",
                 "ent": "^2.2.0",
                 "extend": "^3.0.2",
-                "google-auth-library": "^5.5.0",
-                "retry-request": "^4.0.0",
-                "teeny-request": "^6.0.0"
+                "google-auth-library": "^7.0.2",
+                "retry-request": "^4.2.2",
+                "teeny-request": "^7.0.0"
             },
             "dependencies": {
                 "arrify": {
@@ -12369,27 +12473,28 @@
             }
         },
         "@google-cloud/projectify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.4.tgz",
-            "integrity": "sha512-ZdzQUN02eRsmTKfBj9FDL0KNDIFNjBn/d6tHQmA/+FImH5DO6ZV8E7FzxMgAUiVAUq41RFAkb25p1oHOZ8psfg=="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-2.1.1.tgz",
+            "integrity": "sha512-+rssMZHnlh0twl122gXY4/aCrk0G1acBqkHFfYddtsqpYXGxA29nj9V5V9SfC+GyOG00l650f6lG9KL+EpFEWQ=="
         },
         "@google-cloud/promisify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.4.tgz",
-            "integrity": "sha512-VccZDcOql77obTnFh0TbNED/6ZbbmHDf8UMNnzO1d5g9V0Htfm4k5cllY8P1tJsRKC3zWYGRLaViiupcgVjBoQ=="
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-2.0.4.tgz",
+            "integrity": "sha512-j8yRSSqswWi1QqUGKVEKOG03Q7qOoZP6/h2zN2YO+F5h2+DHU0bSrHCK9Y7lo2DI9fBd8qGAw795sf+3Jva4yA=="
         },
         "@google-cloud/trace-agent": {
-            "version": "4.2.5",
-            "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-4.2.5.tgz",
-            "integrity": "sha512-gVx+7NC5bwVtIZ/Z7jUbnvytwFS1RhF3iWiMyPRKWDohmy5Ixs/QK0fJNgr4Ugs12nstrILG7VfC09q8FOsK4g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/@google-cloud/trace-agent/-/trace-agent-5.1.5.tgz",
+            "integrity": "sha512-8Mrspg9nebd1VA4xC+XQTBBY3PV3SoUR70CHc3waN9lZskrCQO0Ha50VamhtUx8gUMgUK8ANed5EsF8rv+jY4Q==",
             "requires": {
-                "@google-cloud/common": "^2.0.0",
-                "@opencensus/propagation-stackdriver": "0.0.19",
+                "@google-cloud/common": "^3.0.0",
+                "@opencensus/propagation-stackdriver": "0.1.0",
                 "builtin-modules": "^3.0.0",
                 "console-log-level": "^1.4.0",
                 "continuation-local-storage": "^3.2.1",
                 "extend": "^3.0.2",
-                "gcp-metadata": "^3.0.0",
+                "gcp-metadata": "^4.0.0",
+                "google-auth-library": "^7.0.0",
                 "hex2dec": "^1.0.1",
                 "is": "^3.2.0",
                 "methods": "^1.1.1",
@@ -12397,13 +12502,18 @@
                 "semver": "^7.0.0",
                 "shimmer": "^1.2.0",
                 "source-map-support": "^0.5.16",
-                "uuid": "^3.0.1"
+                "uuid": "^8.0.0"
             },
             "dependencies": {
                 "semver": {
                     "version": "7.1.3",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
                     "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 }
             }
         },
@@ -12486,32 +12596,60 @@
             }
         },
         "@opencensus/core": {
-            "version": "0.0.19",
-            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.0.19.tgz",
-            "integrity": "sha512-Y5QXa7vggMU0+jveLcworfX9jNnztix7x1NraAV0uGkTp4y46HrFl0DnNcnNxUDvBu/cYeWRwlmhiWlr9+adOQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@opencensus/core/-/core-0.1.0.tgz",
+            "integrity": "sha512-Bdbi5vi44a1fwyHNyKh6bwzuFZJeZJPhzdwogk/Kw5juoEeRGPworK1sgtB3loeR8cqLyi5us0mz9h0xqINiSQ==",
             "requires": {
                 "continuation-local-storage": "^3.2.1",
                 "log-driver": "^1.2.7",
-                "semver": "^6.0.0",
+                "semver": "^7.0.0",
                 "shimmer": "^1.2.0",
-                "uuid": "^3.2.1"
+                "uuid": "^8.0.0"
             },
             "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
             }
         },
         "@opencensus/propagation-stackdriver": {
-            "version": "0.0.19",
-            "resolved": "https://registry.npmjs.org/@opencensus/propagation-stackdriver/-/propagation-stackdriver-0.0.19.tgz",
-            "integrity": "sha512-TTL9KIOkvTpd+DT2gj3R3JP7XqOAf69ab/wzxIwpBlFqfRiIFBkOALyC/Gy4pKooAe5DemDhXZuRtIa0PgfoZQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@opencensus/propagation-stackdriver/-/propagation-stackdriver-0.1.0.tgz",
+            "integrity": "sha512-YLklu8jnnYKaJ8gUFz3rM0FVdsWXEJAMLzeeU4JRac6LI34raENy4kvRezZtNEFS5KthaJUsYg04sPc/Ag0w4w==",
             "requires": {
-                "@opencensus/core": "^0.0.19",
+                "@opencensus/core": "^0.1.0",
                 "hex2dec": "^1.0.1",
-                "uuid": "^3.2.1"
+                "uuid": "^8.0.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
             }
         },
         "@sinonjs/commons": {
@@ -12551,9 +12689,9 @@
             "dev": true
         },
         "@tootallnate/once": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.0.0.tgz",
-            "integrity": "sha512-KYyTT/T6ALPkIRd2Ge080X/BsXvy9O0hcWTtMWkPvwAwF99+vn6Dv4GzrFT/Nn1LePr+FFDbRXXlqmsy9lw2zA=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
         },
         "@types/caseless": {
             "version": "0.12.2",
@@ -12753,19 +12891,19 @@
             "dev": true
         },
         "agent-base": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-            "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
             "requires": {
                 "debug": "4"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -13245,9 +13383,9 @@
             }
         },
         "bignumber.js": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-            "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
         },
         "binary-extensions": {
             "version": "1.13.1",
@@ -14435,14 +14573,26 @@
             "dev": true
         },
         "duplexify": {
-            "version": "3.7.1",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-            "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+            "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
             "requires": {
-                "end-of-stream": "^1.0.0",
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.0",
+                "end-of-stream": "^1.4.1",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
             }
         },
         "ecc-jsbn": {
@@ -15167,9 +15317,9 @@
             "dev": true
         },
         "fast-text-encoding": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
-            "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+            "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
         },
         "faye-websocket": {
             "version": "0.10.0",
@@ -15995,21 +16145,21 @@
             "dev": true
         },
         "gaxios": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.1.tgz",
-            "integrity": "sha512-DQOesWEx59/bm63lTX0uHDDXpGTW9oKqNsoigwCoRe2lOb5rFqxzHjLTa6aqEBecLcz69dHLw7rbS068z1fvIQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.1.tgz",
+            "integrity": "sha512-9qXV7yrMCGzTrphl9/YGMVH41oSg0rhn1j3wJWed4Oqk45/hXDD2wBT5J1NjQcqTCcv4g3nFnyQ7reSRHNgBgw==",
             "requires": {
                 "abort-controller": "^3.0.0",
                 "extend": "^3.0.2",
                 "https-proxy-agent": "^5.0.0",
                 "is-stream": "^2.0.0",
-                "node-fetch": "^2.3.0"
+                "node-fetch": "^2.6.1"
             },
             "dependencies": {
                 "is-stream": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+                    "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
                 }
             }
         },
@@ -16023,12 +16173,12 @@
             }
         },
         "gcp-metadata": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.4.0.tgz",
-            "integrity": "sha512-fizmBtCXHp8b7FZuzbgKaixO8DzsSYoEVmMgZIna7x8t6cfBF3eqirODWYxVbgmasA5qudCAKiszfB7yVwroIQ==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+            "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
             "requires": {
-                "gaxios": "^2.1.0",
-                "json-bigint": "^0.3.0"
+                "gaxios": "^4.0.0",
+                "json-bigint": "^1.0.0"
             }
         },
         "get-caller-file": {
@@ -16147,19 +16297,19 @@
             }
         },
         "google-auth-library": {
-            "version": "5.10.1",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
-            "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+            "version": "7.9.1",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.9.1.tgz",
+            "integrity": "sha512-cWGykH2WBR+UuYPGRnGVZ6Cjq2ftQiEIFjQWNIRIauZH7hUWoYTr/lkKUqLTYt5dex77nlWWVQ8aPV80mhfp5w==",
             "requires": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
                 "fast-text-encoding": "^1.0.0",
-                "gaxios": "^2.1.0",
-                "gcp-metadata": "^3.4.0",
-                "gtoken": "^4.1.0",
+                "gaxios": "^4.0.0",
+                "gcp-metadata": "^4.2.0",
+                "gtoken": "^5.0.4",
                 "jws": "^4.0.0",
-                "lru-cache": "^5.0.0"
+                "lru-cache": "^6.0.0"
             },
             "dependencies": {
                 "arrify": {
@@ -16168,26 +16318,26 @@
                     "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
                 },
                 "lru-cache": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-                    "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+                    "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
                     "requires": {
-                        "yallist": "^3.0.2"
+                        "yallist": "^4.0.0"
                     }
                 },
                 "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                    "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
             }
         },
         "google-p12-pem": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
-            "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.2.tgz",
+            "integrity": "sha512-tjf3IQIt7tWCDsa0ofDQ1qqSCNzahXDxdAGJDbruWqu3eCg5CKLYKN+hi0s6lfvzYZ1GDVr+oDF9OOWlDSdf0A==",
             "requires": {
-                "node-forge": "^0.9.0"
+                "node-forge": "^0.10.0"
             }
         },
         "graceful-fs": {
@@ -16639,14 +16789,13 @@
             }
         },
         "gtoken": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
-            "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.1.tgz",
+            "integrity": "sha512-yqOREjzLHcbzz1UrQoxhBtpk8KjrVhuqPE7od1K2uhyxG2BHjKZetlbLw/SPZak/QqTIQW+addS+EcjqQsZbwQ==",
             "requires": {
-                "gaxios": "^2.1.0",
-                "google-p12-pem": "^2.0.0",
-                "jws": "^4.0.0",
-                "mime": "^2.2.0"
+                "gaxios": "^4.0.0",
+                "google-p12-pem": "^3.0.3",
+                "jws": "^4.0.0"
             }
         },
         "gzip-size": {
@@ -16948,11 +17097,11 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -16982,11 +17131,11 @@
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -17609,11 +17758,11 @@
             }
         },
         "json-bigint": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
-            "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
             "requires": {
-                "bignumber.js": "^7.0.0"
+                "bignumber.js": "^9.0.0"
             }
         },
         "json-schema": {
@@ -18335,7 +18484,8 @@
         "mime": {
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+            "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.40.0",
@@ -18944,9 +19094,9 @@
             "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         },
         "node-forge": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-            "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         },
         "nopt": {
             "version": "4.0.1",
@@ -19633,7 +19783,8 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "progress": {
             "version": "2.0.3",
@@ -19747,6 +19898,7 @@
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -20019,20 +20171,20 @@
             "dev": true
         },
         "retry-request": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
-            "integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.2.2.tgz",
+            "integrity": "sha512-xA93uxUD/rogV7BV59agW/JHPGXeREMWiZc9jhcwY4YdZ7QOtC7qbomYg0n4wyk2lJhggjvKvhNX8wln/Aldhg==",
             "requires": {
                 "debug": "^4.1.1",
-                "through2": "^3.0.1"
+                "extend": "^3.0.2"
             },
             "dependencies": {
                 "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "version": "4.3.2",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "requires": {
-                        "ms": "^2.1.1"
+                        "ms": "2.1.2"
                     }
                 },
                 "ms": {
@@ -21442,15 +21594,22 @@
             "optional": true
         },
         "teeny-request": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.2.tgz",
-            "integrity": "sha512-B6fxA0fSnY/bul06NggdN1nywtr5U5Uvt96pHfTi8pi4MNe6++VUWcAAFBrcMeha94s+gULwA5WvagoSZ+AcYg==",
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-7.1.2.tgz",
+            "integrity": "sha512-Mr4NYZuniKDpgcLxdBkDE1CcWy98Aw1ennn6oNofen+XWUvDs+ZZzBAujy6XOAVwwLLZMwEQSfdljUI+ebs4Ww==",
             "requires": {
                 "http-proxy-agent": "^4.0.0",
                 "https-proxy-agent": "^5.0.0",
-                "node-fetch": "^2.2.0",
+                "node-fetch": "^2.6.1",
                 "stream-events": "^1.0.5",
-                "uuid": "^3.3.2"
+                "uuid": "^8.0.0"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+                }
             }
         },
         "text-table": {
@@ -21470,14 +21629,6 @@
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
-        },
-        "through2": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
-            "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
-            "requires": {
-                "readable-stream": "2 || 3"
-            }
         },
         "tiny-lr": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "bugs": "https://github.com/cla-assistant/cla-assistant/issues",
     "contributors": [],
     "dependencies": {
-        "@google-cloud/trace-agent": "^4.2.5",
+        "@google-cloud/trace-agent": "^5.1.5",
         "@octokit/plugin-retry": "^2.2.0",
         "@octokit/plugin-throttling": "^2.4.0",
         "@octokit/rest": "^16.37.0",


### PR DESCRIPTION
This PR updates the google-cloud/trace-agent to the latest version 5.1.5 fixing a whole bunch of security warnings.