### PR TITLE
update angular to 1.8.2 and move to devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
                 "@octokit/plugin-retry": "^3.0.9",
                 "@octokit/plugin-throttling": "^3.5.2",
                 "@octokit/rest": "^18.10.0",
-                "angular": "^1.7.9",
                 "async": "^3.2.1",
                 "body-parser": "^1.19.0",
                 "bunyan": "^1.8.15",
@@ -40,6 +39,7 @@
                 "x-frame-options": "^1.0.0"
             },
             "devDependencies": {
+                "angular": "^1.8.2",
                 "angular-mocks": "^1.7.0",
                 "bootstrap-sass": "^3.2.0",
                 "codeceptjs": "^2.0.7",
@@ -838,9 +838,10 @@
             }
         },
         "node_modules/angular": {
-            "version": "1.7.9",
-            "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.9.tgz",
-            "integrity": "sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ=="
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.2.tgz",
+            "integrity": "sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw==",
+            "dev": true
         },
         "node_modules/angular-mocks": {
             "version": "1.7.0",
@@ -13261,9 +13262,10 @@
             "optional": true
         },
         "angular": {
-            "version": "1.7.9",
-            "resolved": "https://registry.npmjs.org/angular/-/angular-1.7.9.tgz",
-            "integrity": "sha512-5se7ZpcOtu0MBFlzGv5dsM1quQDoDeUTwZrWjGtTNA7O88cD8TEk5IEKCTDa3uECV9XnvKREVUr7du1ACiWGFQ=="
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.2.tgz",
+            "integrity": "sha512-IauMOej2xEe7/7Ennahkbb5qd/HFADiNuLSESz9Q27inmi32zB0lnAsFeLEWcox3Gd1F6YhNd1CP7/9IukJ0Gw==",
+            "dev": true
         },
         "angular-mocks": {
             "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "@octokit/plugin-retry": "^3.0.9",
         "@octokit/plugin-throttling": "^3.5.2",
         "@octokit/rest": "^18.10.0",
-        "angular": "^1.7.9",
         "async": "^3.2.1",
         "body-parser": "^1.19.0",
         "bunyan": "^1.8.15",
@@ -50,6 +49,7 @@
         "x-frame-options": "^1.0.0"
     },
     "devDependencies": {
+        "angular": "^1.8.2",
         "angular-mocks": "^1.7.0",
         "bootstrap-sass": "^3.2.0",
         "codeceptjs": "^2.0.7",


### PR DESCRIPTION
This PR updates angularjs to 1.8.2, the latest supported version (at least until end of year). 

Additionally it moves angular to devDependencies as it is only required during build.