### PR TITLE
use native octokit calls instead of node-fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
                 "memory-cache": "^0.2.0",
                 "merge": "^2.1.1",
                 "mongoose": "^6.0.5",
-                "node-fetch": "^2.6.2",
                 "passport": "^0.4.1",
                 "passport-accesstoken": "^0.1.0",
                 "passport-github": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
         "memory-cache": "^0.2.0",
         "merge": "^2.1.1",
         "mongoose": "^6.0.5",
-        "node-fetch": "^2.6.2",
         "passport": "^0.4.1",
         "passport-accesstoken": "^0.1.0",
         "passport-github": "^1.1.0",

--- a/src/server/graphQueries/github.js
+++ b/src/server/graphQueries/github.js
@@ -2,8 +2,7 @@
 module.exports = {
     getPRCommitters: (owner, repo, number, cursor) => {
         number = typeof number === 'string' ? parseInt(number) : number
-        let query = `
-            query($owner:String! $name:String! $number:Int! $cursor:String!){
+        const query = `query ($owner:String! $name:String! $number:Int! $cursor:String!){
                 repository(owner: $owner, name: $name) {
                 pullRequest(number: $number) {
                     commits(first: 100, after: $cursor) {
@@ -39,15 +38,16 @@ module.exports = {
                     }
                 }
             }
-        }`.replace(/ /g, '')
-        let variables = {
+        }`
+
+        const variables = {
             owner: owner,
             name: repo,
             number: number,
-            cursor: cursor
+            cursor: cursor,
         }
 
-        return JSON.stringify({ query, variables })
+        return { query, variables }
     },
 
     getUserOrgs: (owner, cursor) => {
@@ -73,11 +73,15 @@ module.exports = {
                 }
             }
         }`
-        let variables = { owner }
+
+        const variables = {
+            owner: owner,
+        }
+
         if (cursor) {
             variables.cursor = cursor
         }
 
-        return JSON.stringify({ query, variables }).replace(/ /g, '')
+        return { query, variables }
     }
 }

--- a/src/server/passports/github.js
+++ b/src/server/passports/github.js
@@ -6,7 +6,7 @@ const passport = require('passport')
 const Strategy = require('passport-github').Strategy
 const merge = require('merge')
 const User = require('mongoose').model('User')
-const fetch = require('node-fetch')
+const github = require('../services/github')
 
 function updateToken(item, newToken) {
     item.token = newToken
@@ -15,29 +15,27 @@ function updateToken(item, newToken) {
 }
 
 async function checkToken(item, accessToken) {
-    const baseURL = 'https://api.github.com'
-    const checkAuthApi = `${ baseURL }/applications/${ config.server.github.client }/token`
     const newToken = accessToken
     const oldToken = item.token
-    const accesstokenObject = {
-        access_token: oldToken
-    }
 
     try {
-        const header = {
-            method: 'POST',
-            headers: {
-                'Authorization': 'Basic ' + Buffer.from(config.server.github.client + ':' + config.server.github.secret).toString('base64'),
-                'User-Agent': 'CLA assistant',
-                'Accept': 'application/vnd.github.doctor-strange-preview+json',
-                'Content-Type': 'application/json'
+        const args = {
+            obj: 'apps',
+            fun: 'checkToken',
+            arg: {
+                access_token: oldToken,
+                client_id: config.server.github.client
             },
-            body: JSON.stringify(accesstokenObject)
+            basicAuth: {
+                user: config.server.github.client,
+                pass: config.server.github.secret
+            }
         }
-        const res = await fetch(checkAuthApi, header)
-        const checkTokenResponse = await res.json()
-        if (checkTokenResponse) {
-            if (!(checkTokenResponse && checkTokenResponse.scopes && checkTokenResponse.scopes.indexOf('write:repo_hook') >= 0)) {
+
+        const res = await github.call(args)
+
+        if (res) {
+            if (!(res && res.scopes && res.scopes.indexOf('write:repo_hook') >= 0)) {
                 updateToken(item, newToken)
             } else if (item.repo) {
                 const ghRepo = await repoService.getGHRepo(item)

--- a/src/server/passports/github.js
+++ b/src/server/passports/github.js
@@ -35,13 +35,13 @@ async function checkToken(item, accessToken) {
         const res = await github.call(args)
 
         if (res) {
-            if (!(res && res.scopes && res.scopes.indexOf('write:repo_hook') >= 0)) {
+            if (!(res.scopes && res.scopes.indexOf('write:repo_hook') >= 0)) {
                 updateToken(item, newToken)
             } else if (item.repo) {
                 const ghRepo = await repoService.getGHRepo(item)
                 if (!(ghRepo && ghRepo.permissions && ghRepo.permissions.admin)) {
                     updateToken(item, newToken)
-                    logger.info('Update access token for repo ', item.repo, ' admin rights have been changed')
+                    logger.info(`Update access token for repo ${item.repo} admin rights have been changed`)
                 }
             }
         }

--- a/src/server/services/github.js
+++ b/src/server/services/github.js
@@ -1,4 +1,3 @@
-const fetch = require('node-fetch')
 const cache = require('memory-cache')
 const config = require('../../config')
 const stringify = require('json-stable-stringify')
@@ -99,17 +98,11 @@ const githubService = {
     },
 
     callGraphql: async (query, token) => {
-        const response = await fetch(config.server.github.graphqlEndpoint, {
-            method: 'POST',
-            headers: {
-                'Authorization': `bearer ${token}`,
-                'User-Agent': 'CLA assistant',
-                'Content-Type': 'application/json',
-            },
-            body: query
-        })
-        const dataPromise = response.json()
-        return dataPromise
+        const octokit = new OctokitWithPluginsAndDefaults({ auth: token })
+        const response = await octokit.graphql(query.query, query.variables)
+        // workaround as the other functions expect the response body in the data attribute
+        // TODO: refactor probably
+        return { data: response }
     }
 }
 


### PR DESCRIPTION
This PR replaces the usage of `node-fetch` with the native octokit calls. Doing all our API calls through octokit.