### PR TITLE
Enable actions to deploy arbitrary commit to staging 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
+          git-commit: ${{ github.event.inputs.ref }} || 'refs/heads/master'
           path-to-lcov: ./output/coverage/lcov.info
       - name: build the docker image with committ SHA for staging
         if: github.ref == 'refs/heads/master' || ${{ github.event.inputs.ref }}


### PR DESCRIPTION
This PR adjust the actions workflow to allow the deployment of an  arbitrary commit to our staging system. 

Making it more easy to test PRs before merging them to master. 