### PR TITLE
fix check for workflow dispatch run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
           git-commit: ${{ github.event.inputs.ref || github.sha }}
           path-to-lcov: ./output/coverage/lcov.info
       - name: build the docker image with committ SHA for staging
-        if: github.ref == 'refs/heads/master' || ${{ github.event.inputs.ref }}
+        if: ${{ github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
         run: docker build  -t eu.gcr.io/sap-cla-assistant/cla-assistant:${{ github.event.inputs.ref || github.sha }} .
       - name: build the docker images with tag name and latest for production
         if: startsWith(github.ref, 'refs/tags')
@@ -66,7 +66,7 @@ jobs:
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker push sapclaassistant/claassistant
       - name: push image to gcp during push on master branch for testing in staging
-        if: github.ref == 'refs/heads/master' || ${{ github.event.inputs.ref }}
+        if: ${{ github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
         run: docker push eu.gcr.io/sap-cla-assistant/cla-assistant:${{ github.event.inputs.ref || github.sha }}
       - name: push images to gcp during new release for production usage
         if: startsWith(github.ref, 'refs/tags')
@@ -74,5 +74,5 @@ jobs:
           docker push eu.gcr.io/sap-cla-assistant/cla-assistant:latest
           docker push eu.gcr.io/sap-cla-assistant/cla-assistant:${GITHUB_REF:10}
       - name: deploy to staging cloud run service
-        if: github.ref == 'refs/heads/master' || ${{ github.event.inputs.ref }}
+        if: ${{ github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
         run: gcloud --quiet --project sap-cla-assistant beta run deploy cla-assistant-staging --platform managed --region europe-west1 --image eu.gcr.io/sap-cla-assistant/cla-assistant:${{ github.event.inputs.ref || github.sha }}


### PR DESCRIPTION
This PR fixes the workflow syntax to only run the deployment checks if its either a push to master or a workflow dispatch