### PR TITLE
use createOAuthAppAuth to create authentification when acting as the OAuthApp

### DIFF
--- a/src/tests/server/services/github.js
+++ b/src/tests/server/services/github.js
@@ -104,8 +104,8 @@ describe('github:call', () => {
 
     it('should authenticate when basic authentication is required', async () => {
         expectedAuth = {
-            username: 'user',
-            password: 'pass'
+            clientId: 'user',
+            clientSecret: 'pass'
         }
         callStub.resolves({ data: {}, meta: {} })
         await github.call({


### PR DESCRIPTION
This PR uses the explicit `createOAuthAppAuth` function when working as the OAuthApp. Currently when invoking this method following error is thrown as it tries to use the `clientId` and `clientSecret`
```
Error: [@octokit/auth-token] Token passed to createTokenAuth is not a string
    at Object.createTokenAuth (/Users/d064687/github/cla-assistant/node_modules/@octokit/auth-token/dist-node/index.js:39:11)
    at new Octokit (/Users/d064687/github/cla-assistant/node_modules/@octokit/core/dist-node/index.js:102:32)
    at new _a (/Users/d064687/github/cla-assistant/node_modules/@octokit/core/dist-node/index.js:167:30)
    at new OctokitWithDefaults (/Users/d064687/github/cla-assistant/node_modules/@octokit/core/dist-node/index.js:147:9)
    at new _a (/Users/d064687/github/cla-assistant/node_modules/@octokit/core/dist-node/index.js:167:30)
    at new OctokitWithDefaults (/Users/d064687/github/cla-assistant/node_modules/@octokit/core/dist-node/index.js:147:9)
    at Object.call (/Users/d064687/github/cla-assistant/src/server/src/services/github.js:99:25)
    at checkToken (/Users/d064687/github/cla-assistant/src/server/src/passports/token.js:30:30)
    at Strategy._verify (/Users/d064687/github/cla-assistant/src/server/src/passports/token.js:48:41)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

Most likely this got broken as part  of #759 or #768 

fixes #825 