### PR TITLE
await webhook removal to gracefully handle rejected promises

### DIFF
--- a/src/server/src/api/repo.js
+++ b/src/server/src/api/repo.js
@@ -56,7 +56,7 @@ module.exports = {
 
             if (dbRepo.gist) {
                 try {
-                    webhook.create(req)
+                    await webhook.create(req)
                 } catch (error) {
                     logger.error(`Could not create a webhook for the new repo ${new Error(error)}`)
                 }
@@ -89,7 +89,7 @@ module.exports = {
             req.args.owner = dbRepo.owner
             req.args.repo = dbRepo.repo
             try {
-                webhook.remove(req)
+                await webhook.remove(req)
             } catch (error) {
                 logger.error(`Could not remove the webhook for the repo ${new Error(error)}`)
             }

--- a/src/tests/server/api/repo.js
+++ b/src/tests/server/api/repo.js
@@ -309,6 +309,18 @@ describe('repo', () => {
             assert(webhook.remove.called)
         })
 
+        it('should gracefully handle when webhook removal fails', async () => {
+            webhook.remove.restore()
+            sinon.stub(webhook, 'remove').callsFake(async () => {
+                throw 'No webhook found with base url https://test-cla.com/webhook'
+            })
+            await repo_api.remove(req)
+            assert(req.args.owner)
+            assert(req.args.repo)
+            assert(repo.remove.called)
+            assert(webhook.remove.called)
+        })
+
         it('should remove repo entry but not remove webhook when unlink a null CLA repo', async () => {
             res.repoRemove.data.gist = null
             await repo_api.remove(req)


### PR DESCRIPTION
This PR fixes a bug where the removal of webhooks caused an unhandled rejected promise, if they got already manually removed (or some other problem). Problem was that while we had a try/catch in place to handle this case, we failed to await the promise causing it be an unhandled rejected promise outside of a try/catch.

In Node16 a unhandled promise causes the node process to exit and a hard shutdown. 