### PR TITLE
add support for merge_group status checks

### DIFF
--- a/src/server/src/services/status.js
+++ b/src/server/src/services/status.js
@@ -228,6 +228,17 @@ class StatusService {
         }
         return updateStatusIfNeeded(args, status, false)
     }
+
+    async updateForMergeQueue(args) {
+        logger.debug(`StatusService-->updateForMergeQueue for the repo ${args.owner}/${args.repo}/${args.sha}`)
+        let status = {
+            context: 'license/cla',
+            state: 'success',
+            description: 'Dummy status to green light merge group. CLA checks only happen on Pull Requests.',
+            url: url.claURL(args.owner, args.repo)
+        }
+        return createStatus(args, status.context, status.description, status.state, status.url)
+    }
 }
 
 module.exports = new StatusService()

--- a/src/server/src/webhooks/merge_group.js
+++ b/src/server/src/webhooks/merge_group.js
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and CLA-assistant contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//////////////////////////////////////////////////////////////////////////////////////////////
+// GitHub merge_group Webhook Handler
+// We don't actually check the CLA status of merge_group, but rather green light it directly
+// For a PR to be in the merge queue the CLA check must have passed on the PR level already
+// thus we don't need to check it again during the merge_group
+//////////////////////////////////////////////////////////////////////////////////////////////
+
+// services
+const status = require('../services/status')
+const cla = require('../services/cla')
+const logger = require('../services/logger')
+
+module.exports = {
+    accepts: function (req) {
+        // Currently merge_group only has `checks_requested`
+        // We check anyway to ensure that future adding of more types doesn't impact us
+        return ['checks_requested'].indexOf(req.args.action) > -1 && (req.args.repository && req.args.repository.private == false)
+    },
+    handle: async function (req, res) {
+        res.status(200).send('OK - Will be working on it')
+        const args = {
+            owner: req.args.repository.owner.login,
+            repoId: req.args.repository.id,
+            repo: req.args.repository.name,
+            sha: req.args.merge_group.head_commit.id
+        }
+        args.orgId = req.args.organization ? req.args.organization.id : req.args.repository.owner.id
+        args.handleDelay = req.args.handleDelay != undefined ? req.args.handleDelay : 1 // needed for unitTests
+
+        try {
+            const item = await cla.getLinkedItem(args)
+            let nullCla = !item.gist
+            let isExcluded = item.orgId && item.isRepoExcluded && item.isRepoExcluded(args.repo)
+            if (!nullCla && !isExcluded) {
+                args.token = item.token
+                args.gist = item.gist
+                if (item.repoId) {
+                    args.orgId = undefined
+                }
+                await status.updateForMergeQueue(args)
+            }
+        } catch (e) {
+            logger.warn(e)
+        }
+    }
+}

--- a/src/server/src/webhooks/pull_request.js
+++ b/src/server/src/webhooks/pull_request.js
@@ -141,6 +141,7 @@ module.exports = {
         return ['opened', 'reopened', 'synchronize'].indexOf(req.args.action) > -1 && (req.args.repository && req.args.repository.private == false)
     },
     handle: async function (req, res) {
+        res.status(200).send('OK - Will be working on it')
         const args = {
             owner: req.args.repository.owner.login,
             repoId: req.args.repository.id,
@@ -166,6 +167,5 @@ module.exports = {
         } catch (e) {
             logger.warn(e)
         }
-        res.status(200).send('OK')
     }
 }


### PR DESCRIPTION
This PR adds support for GitHub [new merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).

When a PR is moved to a merge queue it first needed to pass all PR checks and then needs to pass the merge queue checks again. As the CLA is only relevant on the PR level, we just green-light any merge queue check.

To have this work, we need to listen to the new webhook event `merge_group`. This is per-default not enabled and needs to manually added to the webhook under repository -> settings -> webhooks -> CLA hook -> "Merge Group".

Alternatively the GitHub App can be enabled on the repository and will listen for both PR and Merge Group events: https://github.com/apps/cla-assistant



Fixes #972 