### PR TITLE
Mention FerretDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Copy the sample configuration file `.env.example` file to `.env`.
 cp .env.example .env
 ```
 
-You require a MongoDB or compatible database such as [Azure Cosmos DB](https://cosmos.azure.com) or [FerretDB](https://www.ferretdb.io) as a backend.
+You require a MongoDB or compatible database as a backend such as: 
+-  [Azure Cosmos DB](https://cosmos.azure.com)
+-  [FerretDB](https://www.ferretdb.io) and [their blog post about using it with CLA Assistant](https://blog.ferretdb.io/using-cla-assistant-with-ferretdb/)
 For development purposes you can run MongoDB in a docker container easily:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The possible values for the "githubKey"-property can be found in the [GitHub-API
 
 ## FAQ
 #### Where is the list of signees stored?
-Since 27.08.2021 all data is stored in a cosmosDB (mongoDB compatible) hosted on Microsoft Azure in Europe ([#740](https://github.com/cla-assistant/cla-assistant/issues/740)).
+Since 27.08.2021 all data is stored in a Cosmos DB (MongoDB compatible) hosted on Microsoft Azure in Europe ([#740](https://github.com/cla-assistant/cla-assistant/issues/740)).
 Before that all the data was stored in a MongoDB hosted by [mLab](https://mlab.com/).
 
 #### Where can I see the list of signees? Is there a way to import/export the signee data?
@@ -129,7 +129,8 @@ Copy the sample configuration file `.env.example` file to `.env`.
 cp .env.example .env
 ```
 
-You require a MongoDB compatible database as a backend. For development purposes you can run MongoDB in a docker container easily:
+You require a MongoDB or compatible database such as [Azure Cosmos DB](https://cosmos.azure.com) or [FerretDB](https://www.ferretdb.io) as a backend.
+For development purposes you can run MongoDB in a docker container easily:
 
 ```sh
 docker run --detach --publish 27017:27017 mongo

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ cp .env.example .env
 You require a MongoDB or compatible database as a backend such as: 
 -  [Azure Cosmos DB](https://cosmos.azure.com)
 -  [FerretDB](https://www.ferretdb.io) and [their blog post about using it with CLA Assistant](https://blog.ferretdb.io/using-cla-assistant-with-ferretdb/)
+
 For development purposes you can run MongoDB in a docker container easily:
 
 ```sh


### PR DESCRIPTION
This PR expands README to mention two MongoDB-compatible alternatives: Cosmos DB (already discussed above) and FerretDB. I'm a maintainer of the latter. FerretDB has been [fully compatible](https://blog.ferretdb.io/using-cla-assistant-with-ferretdb/) with CLA Assistant for almost a year now. Currently, [we work with SAP](https://blogs.sap.com/2022/12/13/introduction-to-sap-hana-compatibility-layer-for-mongodb-wire-protocol/) to provide a MongoDB compatibility layer for SAP HANA.