### PR TITLE
templates/my-cla: fix punctuation.

### DIFF
--- a/src/client/assets/templates/my-cla.html
+++ b/src/client/assets/templates/my-cla.html
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
 </div> -->
 <div class="row main" style="margin-top: 70px;">
     <div class="row">
-        <h4 class="col-xs-12" style="margin-bottom: 25px; padding-left: 0;">Signed CLA's</h4>
+        <h4 class="col-xs-12" style="margin-bottom: 25px; padding-left: 0;">Signed CLAs</h4>
     </div>
     <div class="well row" style="padding-top: 25px;">
         <table class="table">


### PR DESCRIPTION
"CLA's" specifies ownership of something by the CLA but, in this case, it's just intended as the plural form ("CLAs").