### PR TITLE
Add option to disable full index

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The following are the environment variables you have to configure to run a priva
 | `GITHUB_APP_CLIENT`         | The client ID of the registered GitHub App.                                                               |
 | `GITHUB_APP_SECRET`         | The client secret of the registered GitHub App.                                                           |
 | `MONGODB`                   | The URI for the MongoDB database (e. g. `mongodb://<user>:<password>@<host>:<port>/<dbname>`).            |
+| `DISABLE_FULL_INDEX`        | Whether to disable the full index of the cla database (required for AWS DocumentDB compatibility)         |
 
 
 These are optional environment variables:

--- a/src/server/src/config.js
+++ b/src/server/src/config.js
@@ -81,7 +81,8 @@ module.exports = {
         },
 
         mongodb: {
-            uri: process.env.MONGODB || process.env.MONGOLAB_URI
+            uri: process.env.MONGODB || process.env.MONGOLAB_URI,
+            disable_full_index: (!!process.env.DISABLE_FULL_INDEX && process.env.DISABLE_FULL_INDEX === 'true')
         },
 
         slack: {

--- a/src/server/src/documents/cla.js
+++ b/src/server/src/documents/cla.js
@@ -34,6 +34,10 @@ const CLA = mongoose.model('CLA', CLASchema)
 
 // add a full wildcard index for better indexing
 CLA.collection.createIndex({ '$**' : 1 })
+if (!global.config.server.mongodb.disable_full_index) {
+    CLA.collection.createIndex({ '$**' : 1 })
+}
+
 module.exports = {
     CLA: CLA
 }


### PR DESCRIPTION
Fixes #1026

Currently, on startup a full index is created on the `cla` model. The type of index is unsupported by AWS DocumentDB and an unhandled promise rejection is thrown causing recent versions of NodeJS to crash in their default configuration. This is only a performance optimization and is not needed for self-hosted installations which are unlikely to reach the scale required by the hosted version.

This PR introduces an option to disable the full index, allowing the CLA assistant to run without problems on AWS DocumentDB